### PR TITLE
Fix #433; Exporting Long URIs In Chrome

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2116,7 +2116,7 @@ BlockMorph.prototype.userMenu = function () {
     menu.addItem(
         "script pic...",
         function () {
-            window.open(myself.topBlock().fullImage().toDataURL());
+            openURI(myself.topBlock().fullImage().toDataURL());
         },
         'open a new window\nwith a picture of this script'
     );
@@ -5024,7 +5024,7 @@ ScriptsMorph.prototype.cleanUp = function () {
 ScriptsMorph.prototype.exportScriptsPicture = function () {
     var pic = this.scriptsPicture();
     if (pic) {
-        window.open(pic.toDataURL());
+        openURI(pic.toDataURL());
     }
 };
 
@@ -10669,7 +10669,7 @@ CommentMorph.prototype.userMenu = function () {
     menu.addItem(
         "comment pic...",
         function () {
-            window.open(myself.fullImage().toDataURL());
+            openURI(myself.fullImage().toDataURL());
         },
         'open a new window\nwith a picture of this comment'
     );

--- a/byob.js
+++ b/byob.js
@@ -734,7 +734,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
         menu.addItem(
             "script pic...",
             function () {
-                window.open(this.topBlock().fullImage().toDataURL());
+                openURI(this.topBlock().fullImage().toDataURL());
             },
             'open a new window\nwith a picture of this script'
         );
@@ -755,7 +755,7 @@ CustomCommandBlockMorph.prototype.userMenu = function () {
 
 CustomCommandBlockMorph.prototype.exportBlockDefinition = function () {
     var xml = new SnapSerializer().serialize(this.definition);
-    window.open('data:text/xml,' + encodeURIComponent(xml));
+    openURI('data:text/xml,' + encodeURIComponent(xml));
 };
 
 CustomCommandBlockMorph.prototype.deleteBlockDefinition = function () {
@@ -3280,7 +3280,7 @@ BlockExportDialogMorph.prototype.selectNone = function () {
 BlockExportDialogMorph.prototype.exportBlocks = function () {
     var str = this.serializer.serialize(this.blocks);
     if (this.blocks.length > 0) {
-        window.open(encodeURI('data:text/xml,<blocks app="'
+        openURI(encodeURI('data:text/xml,<blocks app="'
             + this.serializer.app
             + '" version="'
             + this.serializer.version

--- a/gui.js
+++ b/gui.js
@@ -1890,19 +1890,19 @@ IDE_Morph.prototype.snapMenu = function () {
     menu.addItem(
         'Reference manual',
         function () {
-            window.open('help/SnapManual.pdf', 'SnapReferenceManual');
+            openURI('help/SnapManual.pdf', 'SnapReferenceManual');
         }
     );
     menu.addItem(
         'Snap! website',
         function () {
-            window.open('http://snap.berkeley.edu/', 'SnapWebsite');
+            openURI('http://snap.berkeley.edu/', 'SnapWebsite');
         }
     );
     menu.addItem(
         'Download source',
         function () {
-            window.open(
+            openURI(
                 'http://snap.berkeley.edu/snapsource/snap.zip',
                 'SnapSource'
             );
@@ -2032,7 +2032,7 @@ IDE_Morph.prototype.cloudMenu = function () {
                             function (projectData) {
                                 var msg;
                                 if (!Process.prototype.isCatchingErrors) {
-                                    window.open(
+                                    openURI(
                                         'data:text/xml,' + projectData
                                     );
                                 }
@@ -2710,7 +2710,7 @@ IDE_Morph.prototype.newProject = function () {
         this.stage.destroy();
     }
     if (location.hash.substr(0, 6) !== '#lang:') {
-        location.hash = '';
+        setLocationHash('');
     }
     this.globalVariables = new VariableFrame();
     this.currentSprite = new SpriteMorph(this.globalVariables);
@@ -2766,7 +2766,7 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
             try {
                 localStorage['-snap-project-' + name]
                     = str = this.serializer.serialize(this.stage);
-                location.hash = '#open:' + str;
+                setLocationHash('#open:' + str);
                 this.showMessage('Saved!', 1);
             } catch (err) {
                 this.showMessage('Save failed: ' + err);
@@ -2774,7 +2774,7 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
         } else {
             localStorage['-snap-project-' + name]
                 = str = this.serializer.serialize(this.stage);
-            location.hash = '#open:' + str;
+            setLocationHash('#open:' + str);
             this.showMessage('Saved!', 1);
         }
     }
@@ -2815,8 +2815,8 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
                 str = encodeURIComponent(
                     this.serializer.serialize(this.stage)
                 );
-                location.hash = '#open:' + str;
-                window.open('data:text/'
+                setLocationHash('#open:' + str);
+                openURI('data:text/'
                     + (plain ? 'plain,' + str : 'xml,' + str));
                 menu.destroy();
                 this.showMessage('Exported!', 1);
@@ -2828,8 +2828,8 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
             str = encodeURIComponent(
                 this.serializer.serialize(this.stage)
             );
-            location.hash = '#open:' + str;
-            window.open('data:text/'
+            setLocationHash('#open:' + str);
+            openURI('data:text/'
                 + (plain ? 'plain,' + str : 'xml,' + str));
             menu.destroy();
             this.showMessage('Exported!', 1);
@@ -2854,7 +2854,7 @@ IDE_Morph.prototype.exportGlobalBlocks = function () {
 
 IDE_Morph.prototype.exportSprite = function (sprite) {
     var str = this.serializer.serialize(sprite);
-    window.open('data:text/xml,<sprites app="'
+    openURI('data:text/xml,<sprites app="'
         + this.serializer.app
         + '" version="'
         + this.serializer.version
@@ -2910,7 +2910,7 @@ IDE_Morph.prototype.exportScriptsPicture = function () {
         y += each.height;
     });
 
-    window.open(pic.toDataURL());
+    openURI(pic.toDataURL());
 };
 
 IDE_Morph.prototype.openProjectString = function (str) {
@@ -3086,7 +3086,7 @@ IDE_Morph.prototype.openProject = function (name) {
         this.setProjectName(name);
         str = localStorage['-snap-project-' + name];
         this.openProjectString(str);
-        location.hash = '#open:' + str;
+        setLocationHash('#open:' + str);
     }
 };
 
@@ -3815,7 +3815,7 @@ IDE_Morph.prototype.exportProjectMedia = function (name) {
                 media = encodeURIComponent(
                     this.serializer.mediaXML(name)
                 );
-                window.open('data:text/xml,' + media);
+                openURI('data:text/xml,' + media);
                 menu.destroy();
                 this.showMessage('Exported!', 1);
             } catch (err) {
@@ -3830,7 +3830,7 @@ IDE_Morph.prototype.exportProjectMedia = function (name) {
             media = encodeURIComponent(
                 this.serializer.mediaXML()
             );
-            window.open('data:text/xml,' + media);
+            openURI('data:text/xml,' + media);
             menu.destroy();
             this.showMessage('Exported!', 1);
         }
@@ -3851,7 +3851,7 @@ IDE_Morph.prototype.exportProjectNoMedia = function (name) {
                 str = encodeURIComponent(
                     this.serializer.serialize(this.stage)
                 );
-                window.open('data:text/xml,' + str);
+                openURI('data:text/xml,' + str);
                 menu.destroy();
                 this.showMessage('Exported!', 1);
             } catch (err) {
@@ -3863,7 +3863,7 @@ IDE_Morph.prototype.exportProjectNoMedia = function (name) {
             str = encodeURIComponent(
                 this.serializer.serialize(this.stage)
             );
-            window.open('data:text/xml,' + str);
+            openURI('data:text/xml,' + str);
             menu.destroy();
             this.showMessage('Exported!', 1);
         }
@@ -3890,7 +3890,7 @@ IDE_Morph.prototype.exportProjectAsCloudData = function (name) {
                     + str
                     + media
                     + encodeURIComponent('</snapdata>');
-                window.open('data:text/xml,' + dta);
+                openURI('data:text/xml,' + dta);
                 menu.destroy();
                 this.showMessage('Exported!', 1);
             } catch (err) {
@@ -3909,7 +3909,7 @@ IDE_Morph.prototype.exportProjectAsCloudData = function (name) {
                 + str
                 + media
                 + encodeURIComponent('</snapdata>');
-            window.open('data:text/xml,' + dta);
+            openURI('data:text/xml,' + dta);
             menu.destroy();
             this.showMessage('Exported!', 1);
         }
@@ -4712,10 +4712,10 @@ ProjectDialogMorph.prototype.rawOpenCloudProject = function (proj) {
                     myself.ide.source = 'cloud';
                     myself.ide.droppedText(response[0].SourceCode);
                     if (proj.Public === 'true') {
-                        location.hash = '#present:Username=' +
+                        setLocationHash('#present:Username=' +
                             encodeURIComponent(SnapCloud.username) +
                             '&ProjectName=' +
-                            encodeURIComponent(proj.ProjectName);
+                            encodeURIComponent(proj.ProjectName));
                     }
                 },
                 myself.ide.cloudError(),
@@ -5248,7 +5248,7 @@ SpriteIconMorph.prototype.userMenu = function () {
         menu.addItem(
             'pic...',
             function () {
-                window.open(myself.object.fullImageClassic().toDataURL());
+                openURI(myself.object.fullImageClassic().toDataURL());
             },
             'open a new window\nwith a picture of the stage'
         );
@@ -5598,9 +5598,9 @@ CostumeIconMorph.prototype.removeCostume = function () {
 
 CostumeIconMorph.prototype.exportCostume = function () {
     if (this.object instanceof SVG_Costume) {
-        window.open(this.object.contents.src);
+        openURI(this.object.contents.src);
     } else { // rastered Costume
-        window.open(this.object.contents.toDataURL());
+        openURI(this.object.contents.toDataURL());
     }
 };
 

--- a/gui.js
+++ b/gui.js
@@ -2852,13 +2852,8 @@ IDE_Morph.prototype.exportGlobalBlocks = function () {
 };
 
 IDE_Morph.prototype.exportSprite = function (sprite) {
-<<<<<<< HEAD
-    var str = this.serializer.serialize(sprite);
-    openURI('data:text/xml,<sprites app="'
-=======
     var str = this.serializer.serialize(sprite.allParts());
-    window.open('data:text/xml,<sprites app="'
->>>>>>> master
+    openURI('data:text/xml,<sprites app="'
         + this.serializer.app
         + '" version="'
         + this.serializer.version

--- a/morphic.js
+++ b/morphic.js
@@ -1270,6 +1270,43 @@ function copy(target) {
     return c;
 }
 
+/* These are a workaround for a limitation of Chrome which only supports
+ * URLs less than 2.09 characters long (~2.09MB). In in such cases Chrome
+ * will display an "Aw, snap" page.
+ *
+ *  hasChromeBug merely checks for Chrome and the length of the resource
+ *  setLocationHash prevents the URL of the current page from being set.
+ *      If set on a URL too long, all the user's work could be lost.
+ *  openURI simply warns when an item won't export as expected.
+ *      The error message is generic because projects, blocks, images, etc.
+ *      could be exported via this method.
+ */
+
+var hasChromeBug = function(resource) {
+    var isChrome  = navigator.userAgent.indexOf('Chrome') !== -1,
+        isTooLong = resource.length > 2.08e6;
+
+    return isChrome && isTooLong;
+}
+
+function setLocationHash(hash) {
+    if (hasChromeBug(hash)) {
+        location.hash = '';
+    } else {
+        location.hash = hash;
+    }
+}
+
+function openURI(resource, title) {
+    if (hasChromeBug(resource)) {
+        throw new Error('Sorry, this item cannot be exported from Chrome.' +
+        '\nPlease try a different browser.');
+    }
+
+    window.open(resource, title);
+}
+
+
 // Colors //////////////////////////////////////////////////////////////
 
 // Color instance creation:
@@ -3439,7 +3476,7 @@ Morph.prototype.developersMenu = function () {
     menu.addItem(
         "pic...",
         function () {
-            window.open(this.fullImageClassic().toDataURL());
+            openURI(this.fullImageClassic().toDataURL());
         },
         'open a new window\nwith a picture of this morph'
     );

--- a/objects.js
+++ b/objects.js
@@ -5188,7 +5188,7 @@ StageMorph.prototype.userMenu = function () {
     menu.addItem(
         "pic...",
         function () {
-            window.open(myself.fullImageClassic().toDataURL());
+            openURI(myself.fullImageClassic().toDataURL());
         },
         'open a new window\nwith a picture of the stage'
     );
@@ -6968,7 +6968,7 @@ WatcherMorph.prototype.userMenu = function () {
             menu.addItem(
                 'export...',
                 function () {
-                    window.open(
+                    openURI(
                         'data:text/plain;charset=utf-8,' +
                             encodeURIComponent(this.currentValue.toString())
                     );

--- a/widgets.js
+++ b/widgets.js
@@ -1919,7 +1919,7 @@ DialogBoxMorph.prototype.promptCredentials = function (
         var btn = new PushButtonMorph(
             myself,
             function () {
-                window.open(url);
+                openURI(url);
             },
             '  ' + localize(label) + '  '
         );


### PR DESCRIPTION
This fixes an issue where Chrome displays an "Aw, snap" error page
when the URL field is > ~2.09 million characters. In Snap! this occurs
in projects with lots of media, or exporting large images.

This puts a wrapper around setting `location.hash` and around `window.open`
which are the two ways Snap! will display data in the URL bar. The
location.hash issue is particularly bad because it causes the state of
the current tab to be lost, leading to unsaved work. In this case, when an
error occurs, I've set the hash to '', which shouldn't affect the user.

When a new window is attempting to open, an error is thrown an displayed
in Snap! instructing the user to try another browser. (A more specific
message could be provided if we wanted, but this currently applies to any
exported item.)