### PR TITLE
Disable putting project contents in location.hash

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2765,7 +2765,6 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
             try {
                 localStorage['-snap-project-' + name]
                     = str = this.serializer.serialize(this.stage);
-                location.hash = '#open:' + str;
                 this.showMessage('Saved!', 1);
             } catch (err) {
                 this.showMessage('Save failed: ' + err);
@@ -2773,7 +2772,6 @@ IDE_Morph.prototype.rawSaveProject = function (name) {
         } else {
             localStorage['-snap-project-' + name]
                 = str = this.serializer.serialize(this.stage);
-            location.hash = '#open:' + str;
             this.showMessage('Saved!', 1);
         }
     }
@@ -2814,7 +2812,6 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
                 str = encodeURIComponent(
                     this.serializer.serialize(this.stage)
                 );
-                location.hash = '#open:' + str;
                 window.open('data:text/'
                     + (plain ? 'plain,' + str : 'xml,' + str));
                 menu.destroy();
@@ -2827,7 +2824,6 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
             str = encodeURIComponent(
                 this.serializer.serialize(this.stage)
             );
-            location.hash = '#open:' + str;
             window.open('data:text/'
                 + (plain ? 'plain,' + str : 'xml,' + str));
             menu.destroy();
@@ -3085,7 +3081,6 @@ IDE_Morph.prototype.openProject = function (name) {
         this.setProjectName(name);
         str = localStorage['-snap-project-' + name];
         this.openProjectString(str);
-        location.hash = '#open:' + str;
     }
 };
 


### PR DESCRIPTION
This is a **partial** resolution to #433 which causes Chrome to crash.
Placing the project contents in the URL bar will lead to crashes on Chrome
when the URL text is > 2.09 million characters. This fix does not resolve
the problem of exporting a project (Chrome will 'crash' the new tab's process),
but at least the contents of current tab (Snap!) will remain intact.

One other benefit is that browser histories for Snap! users will decrease in
size. This has a noticeable affect in Safari on OS X where large histories slow
down searching and URL-autocomplete.

Use of #open:<project...> will still work the same, and in the case of opening
a shared cloud project, #present... is still set in the URL bar. This could (in
theory) leave open the possibly of a Chrome crash if a username or project title
are longer than 2.09m characters. However, such a case seems incredibly
unlikely.