### PR TITLE
allow only numbers to be reported as number

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -118,6 +118,15 @@ function snapEquals(a, b) {
     return x === y;
 }
 
+// stricter alternative to parseFloat
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat/
+function filterFloat(value) {
+    if(/^(\-|\+)?([0-9]+(\.[0-9]+)?|Infinity)$/
+        .test(value))
+        return Number(value);
+    return NaN;
+}
+
 // ThreadManager ///////////////////////////////////////////////////////
 
 function ThreadManager() {
@@ -1847,13 +1856,14 @@ Process.prototype.reportIsA = function (thing, typeString) {
 Process.prototype.reportTypeOf = function (thing) {
     // answer a string denoting the argument's type
     var exp;
+
     if (thing === null || (thing === undefined)) {
         return 'nothing';
     }
     if (thing === true || (thing === false)) {
         return 'Boolean';
     }
-    if (!isNaN(parseFloat(thing))) {
+    if (!isNaN(filterFloat(thing))) {
         return 'number';
     }
     if (isString(thing)) {


### PR DESCRIPTION
`is 3ab a number` now returns `false`.
Other blocks still convert it to `3`.