### PR TITLE
Fix Errors when project can't be opened

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -284,7 +284,7 @@ IDE_Morph.prototype.openIn = function (world) {
             }
             throw new Error('unable to retrieve ' + url);
         } catch (err) {
-            return;
+            return '';
         }
     }
 

--- a/gui.js
+++ b/gui.js
@@ -284,6 +284,7 @@ IDE_Morph.prototype.openIn = function (world) {
             }
             throw new Error('unable to retrieve ' + url);
         } catch (err) {
+			myself.showMessage('unable to load\n' + url);
             return '';
         }
     }


### PR DESCRIPTION
This is a partial fix for #573, which deals with errors for opening
remote project links. Returning '' causes Snap! to load normally.
The perfect fix would be to bubble up an error message to the user
after Snap! has loaded. (Simply throwing an error will not work because
the throw in getURL() won't be caught by morphic.)