### PR TITLE
Initial Version of Retina Scaling

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -1079,6 +1079,20 @@ var touchScreenSettings = {
 
 var MorphicPreferences = standardSettings;
 
+var PIXEL_RATIO = (function () {
+    // Get the window's pixel ratio for canvas elements.
+    // See: http://www.html5rocks.com/en/tutorials/canvas/hidpi/
+    var ctx = document.createElement("canvas").getContext("2d"),
+        dpr = window.devicePixelRatio || 1,
+        bsr = ctx.webkitBackingStorePixelRatio ||
+              ctx.mozBackingStorePixelRatio ||
+              ctx.msBackingStorePixelRatio ||
+              ctx.oBackingStorePixelRatio ||
+              ctx.backingStorePixelRatio || 1;
+
+    return dpr / bsr;
+})();
+
 // Global Functions ////////////////////////////////////////////////////
 
 function nop() {
@@ -1147,6 +1161,20 @@ function fontHeight(height) {
     return minHeight * 1.2; // assuming 1/5 font size for ascenders
 }
 
+function retinaScale(canvas) {
+    // Scale a canvas element by the display pixel ratio
+    var width  = canvas.width,
+        height = canvas.height,
+        ratio  = PIXEL_RATIO || 1,
+        ctx    = canvas.getContext('2d');
+
+        canvas.style.width  = width + 'px';
+        canvas.style.height = height + 'px';
+        canvas.height = height * ratio;
+        canvas.width  = width * ratio;
+        ctx.scale(ratio, ratio);
+};
+
 function newCanvas(extentPoint) {
     // answer a new empty instance of Canvas, don't display anywhere
     var canvas, ext;
@@ -1154,6 +1182,8 @@ function newCanvas(extentPoint) {
     canvas = document.createElement('canvas');
     canvas.width = ext.x;
     canvas.height = ext.y;
+    // Do Not Enable this or too many morphs will be wrongly sized.
+    // retinaScale(canvas);
     return canvas;
 }
 

--- a/snap.html
+++ b/snap.html
@@ -1,37 +1,38 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-		<title>Snap! Build Your Own Blocks. Beta</title>
-        <link rel="shortcut icon" href="http://snap.berkeley.edu/fav3.gif" type="image/gif">
-		<script type="text/javascript" src="morphic.js"></script>
-		<script type="text/javascript" src="widgets.js"></script>
-		<script type="text/javascript" src="blocks.js"></script>
-		<script type="text/javascript" src="threads.js"></script>
-		<script type="text/javascript" src="objects.js"></script>
-		<script type="text/javascript" src="gui.js"></script>
-		<script type="text/javascript" src="paint.js"></script>
-		<script type="text/javascript" src="lists.js"></script>
-		<script type="text/javascript" src="byob.js"></script>
-		<script type="text/javascript" src="xml.js"></script>
-		<script type="text/javascript" src="store.js"></script>
-		<script type="text/javascript" src="locale.js"></script>
-		<script type="text/javascript" src="cloud.js"></script>
-		<script type="text/javascript" src="sha512.js"></script>
-		<script type="text/javascript">
-			var world;
-			window.onload = function () {
-				world = new WorldMorph(document.getElementById('world'));
-                world.worldCanvas.focus();
-				new IDE_Morph().openIn(world);
-				setInterval(loop, 1);
-			};
-			function loop() {
-				world.doOneCycle();
-			}
-		</script>
-	</head>
-	<body style="margin: 0;">
-		<canvas id="world" tabindex="1" style="position: absolute;" />
-    </body>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <title>Snap! Build Your Own Blocks. Beta</title>
+    <link rel="shortcut icon" href="http://snap.berkeley.edu/fav3.gif" type="image/gif">
+    <script type="text/javascript" src="morphic.js"></script>
+    <script type="text/javascript" src="widgets.js"></script>
+    <script type="text/javascript" src="blocks.js"></script>
+    <script type="text/javascript" src="threads.js"></script>
+    <script type="text/javascript" src="objects.js"></script>
+    <script type="text/javascript" src="gui.js"></script>
+    <script type="text/javascript" src="paint.js"></script>
+    <script type="text/javascript" src="lists.js"></script>
+    <script type="text/javascript" src="byob.js"></script>
+    <script type="text/javascript" src="xml.js"></script>
+    <script type="text/javascript" src="store.js"></script>
+    <script type="text/javascript" src="locale.js"></script>
+    <script type="text/javascript" src="cloud.js"></script>
+    <script type="text/javascript" src="sha512.js"></script>
+    <script type="text/javascript">
+      var world;
+      window.onload = function () {
+        world = new WorldMorph(document.getElementById('world'));
+        world.worldCanvas.focus();
+        new IDE_Morph().openIn(world);
+        retinaScale(document.getElementById('world'));
+        setInterval(loop, 1);
+      };
+      function loop() {
+        world.doOneCycle();
+      }
+    </script>
+  </head>
+  <body style="margin: 0;">
+    <canvas id="world" tabindex="1" style="position: absolute;" />
+  </body>
 </html>


### PR DESCRIPTION
This adds a new function and variable to Morphic.
Variable: `PIXEL_RATIO` represents the browser's internal scaling or canvas's.
`retinaScale(canvas)` will scale the canvas based on the pixel ratio's the
browser is using.

Right now, only the main `world` canvas is scaled, which still represents a nice
improvement -- individual lines are much sharper. However, text and some
graphics are still a bit blurry. It seems like modifying `newCanvas()` to scale
a canvas when it's created is the right move, but this leads to poor scaling and
many elements appearing larger than they should.

(I also replaced the tabs with spaces when I modified snap.html since that's
what my editor did...and it's consistent with the JS files.)