### PR TITLE
Restrict "Save to Disk" to only show in supported browsers

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2874,7 +2874,10 @@ IDE_Morph.prototype.saveProjectToDisk = function () {
             link.setAttribute('href', 'data:text/xml,' + data);
             link.setAttribute('download', this.projectName + '.xml');
             document.body.appendChild(link);
+            console.log('URL Created...');
+            console.log(link);
             link.click();
+            console.log('Did Chrome error?');
             document.body.removeChild(link);
         } catch (err) {
             this.showMessage('Saving failed: ' + err);
@@ -2884,7 +2887,10 @@ IDE_Morph.prototype.saveProjectToDisk = function () {
         link.setAttribute('href', 'data:text/xml,' + data);
         link.setAttribute('download', this.projectName + '.xml');
         document.body.appendChild(link);
+        console.log('URL Created...');
+        console.log(link);
         link.click();
+        console.log('Did Chrome error?');
         document.body.removeChild(link);
     }
 };
@@ -2900,8 +2906,10 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
                     this.serializer.serialize(this.stage)
                 );
                 this.setURL('#open:' + str);
+                console.log('URL Not Set... error?');
                 window.open('data:text/'
                     + (plain ? 'plain,' + str : 'xml,' + str));
+                console.log('error?');
                 menu.destroy();
                 this.showMessage('Exported!', 1);
             } catch (err) {
@@ -2913,8 +2921,10 @@ IDE_Morph.prototype.exportProject = function (name, plain) {
                 this.serializer.serialize(this.stage)
             );
             this.setURL('#open:' + str);
+            console.log('URL Not Set... error?');
             window.open('data:text/'
                 + (plain ? 'plain,' + str : 'xml,' + str));
+            console.log('error??');
             menu.destroy();
             this.showMessage('Exported!', 1);
         }

--- a/gui.js
+++ b/gui.js
@@ -2384,12 +2384,13 @@ IDE_Morph.prototype.projectMenu = function () {
     menu.addItem('New', 'createNewProject');
     menu.addItem('Open...', 'openProjectsBrowser');
     menu.addItem('Save', "save");
-    menu.addItem(
-        'Save to disk',
-        'saveProjectToDisk',
-        'store this project\nin the downloads folder\n'
-            + '(in supporting browsers)'
-    );
+    if ('download' in document.createElement('a')) {
+        menu.addItem(
+            'Save to disk',
+            'saveProjectToDisk',
+            'store this project\nin the downloads folder'
+        );
+    }
     menu.addItem('Save As...', 'saveProjectsBrowser');
     menu.addLine();
     menu.addItem(

--- a/threads.js
+++ b/threads.js
@@ -461,6 +461,8 @@ Process.prototype.evaluateContext = function () {
     var exp = this.context.expression;
     this.frameCount += 1;
     if (this.context.tag === 'exit') {
+        console.log('error?');
+        console.log(this);
         this.expectReport();
     }
     if (exp instanceof Array) {
@@ -741,6 +743,9 @@ Process.prototype.handleError = function (error, element) {
     this.errorFlag = true;
     this.topBlock.addErrorHighlight();
     if (isNil(m) || isNil(m.world())) {m = this.topBlock; }
+    console.log(m);
+    console.log(error);
+    console.log(this);
     m.showBubble(
         (m === element ? '' : 'Inside: ')
             + error.name


### PR DESCRIPTION
This makes it so that only supported browsers show the save to disk
function
(currently Chrome 30x+ and FF36(?)+) This prevents unexpected behavior in
Safari and IE, and will automatically show the menu should these browsers
ever get support.