### PR TITLE
Restrict "Save to Disk" to only show in supported browsers

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2384,12 +2384,13 @@ IDE_Morph.prototype.projectMenu = function () {
     menu.addItem('New', 'createNewProject');
     menu.addItem('Open...', 'openProjectsBrowser');
     menu.addItem('Save', "save");
-    menu.addItem(
-        'Save to disk',
-        'saveProjectToDisk',
-        'store this project\nin the downloads folder\n'
-            + '(in supporting browsers)'
-    );
+    if ('download' in document.createElement('a')) {
+        menu.addItem(
+            'Save to disk',
+            'saveProjectToDisk',
+            'store this project\nin the downloads folder'
+        );
+    }
     menu.addItem('Save As...', 'saveProjectsBrowser');
     menu.addLine();
     menu.addItem(


### PR DESCRIPTION
This makes it so that only supported browsers show the save to disk function
(currently Chrome 30x+ and FF36(?)+)
This prevents unexpected behavior in Safari and IE, and will automatically show
the menu should these browsers ever get support.

(This should one have 1 commit and a clean history!)