### PR TITLE
Added no javascript text.

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -32,6 +32,7 @@
 		</script>
 	</head>
 	<body style="margin: 0;">
+		<noscript><h1>You need javascript enabled for Snap! to run.</h1></noscript>
 		<canvas id="world" tabindex="1" style="position: absolute;" />
 	</body>
 </html>


### PR DESCRIPTION
Since Snap! is ran on javascript, you need your browser to have javascript enabled, so if it's not enabled, let's show some nice big text saying it needs to be on. If needed or recommended, I can add this to the other html files that look like they need this as well. :-)