### PR TITLE
Implement log10 and 10^x math functions

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -1111,9 +1111,9 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
                     acos : ['acos'],
                     atan : ['atan'],
                     ln : ['ln'],
-                    // log : 'log',
-                    'e^' : ['e^']
-                    // '10^' : '10^'
+                    log : ['log'],
+                    'e^' : ['e^'],
+                    '10^' : ['10^']
                 },
                 true
             );

--- a/threads.js
+++ b/threads.js
@@ -2122,14 +2122,14 @@ Process.prototype.reportMonadic = function (fname, n) {
     case 'ln':
         result = Math.log(x);
         break;
-    case 'log':
-        result = 0;
+    case 'log': // base 10
+        result =  Math.log(x) / Math.LN10;
         break;
     case 'e^':
         result = Math.exp(x);
         break;
     case '10^':
-        result = 0;
+        result = Math.pow(10, x);
         break;
     default:
         nop();


### PR DESCRIPTION
These two have been missing from Snap<i>!</i> but exist in Scratch (and BYOB). 

Was there a particular reason they were left out? I suppose it's true that users _cloud_ implement these themselves, but having them here will make compatibility and project conversion easier. :)