### PR TITLE
Fix Error Handing in the DATE block

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -2640,25 +2640,25 @@ Process.prototype.reportTimer = function () {
 };
 
 // Process Dates and times in Snap
-// Map block options to built-in functions
-var dateMap = {
-    'year' : 'getFullYear',
-    'month' : 'getMonth',
-    'date': 'getDate',
-    'day of week' : 'getDay',
-    'hour' : 'getHours',
-    'minute' : 'getMinutes',
-    'second' : 'getSeconds',
-    'time in milliseconds' : 'getTime'
-};
-
 Process.prototype.reportDate = function (datefn) {
     var inputFn = this.inputOption(datefn),
-        currDate = new Date(),
-        func = dateMap[inputFn],
-        result = currDate[func]();
+        // Map block options to built-in functions
+        dateMap = {
+            'year' : 'getFullYear',
+            'month' : 'getMonth',
+            'date': 'getDate',
+            'day of week' : 'getDay',
+            'hour' : 'getHours',
+            'minute' : 'getMinutes',
+            'second' : 'getSeconds',
+            'time in milliseconds' : 'getTime'
+        };
 
     if (!dateMap[inputFn]) { return ''; }
+
+    var currDate = new Date(),
+        func = dateMap[inputFn],
+        result = currDate[func]();
 
     // Show months as 1-12 and days as 1-7
     if (inputFn === 'month' || inputFn === 'day of week') {


### PR DESCRIPTION
For some reason the function wasnt properly catching errors and was instead rasing native
JS errors. This fixes that bug, so the function will now report nothing when it doesnt know
what to do.

In addition, moving the variable `dateMap` inside the function reduces a global variable, which
shouldnt affect anything other than keeping the code clean. :)