### PR TITLE
Fix type issue when adding blanks to lists

### DIFF
--- a/lists.js
+++ b/lists.js
@@ -158,9 +158,8 @@ List.prototype.add = function (element, index) {
     if no index is specifed, append the element
 */
     var idx = index || this.length() + 1,
-        obj = element === 0 ? 0
-                : element === false ? false
-                        : element || null;
+        obj = isNil(element) ? null : element;
+
     this.becomeArray();
     this.contents.splice(idx - 1, 0, obj);
     this.changed();


### PR DESCRIPTION
This is one small change that will need to be tested!
This makes the add function behaves like `in front of` and
uses a call to `isNil()`. Only values that are `nil` will be
added  to the list as `null` (in JS). This is more consistent with
Snap! so that values like the empty string are handled correctly.

This fixes #863. Contains will properly handle empty inputs and
when re-loading a list with blank elements added, they will no
longer be converted to 0's.