### PR TITLE
Add a Ceiling to the monadic math-block-thing

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -1149,6 +1149,7 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
                 false,
                 {
                     abs : ['abs'],
+                    ceiling : ['ceiling'],
                     floor : ['floor'],
                     sqrt : ['sqrt'],
                     sin : ['sin'],

--- a/threads.js
+++ b/threads.js
@@ -2115,6 +2115,9 @@ Process.prototype.reportMonadic = function (fname, n) {
     case 'abs':
         result = Math.abs(x);
         break;
+    case 'ceiling':
+        result = Math.ceil(x);
+        break;
     case 'floor':
         result = Math.floor(x);
         break;


### PR DESCRIPTION
(Does that block have a name?)

This is good for two reasons:
* it just makes sense to have floor and ceiling together
* It's a minor thing for scratch 2 parity.
* it doesn't clutter anything. :grin: