### PR TITLE
Fix #915 so that share URLs actually work.

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -70,7 +70,7 @@ SpeechBubbleMorph, ScriptFocusMorph*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
-modules.gui = '2015-July-28';
+modules.gui = '2015-September-07';
 
 // Declarations
 
@@ -5121,7 +5121,7 @@ ProjectDialogMorph.prototype.shareProject = function () {
                                     encodeURIComponent(usr.toLowerCase()) +
                                     '&ProjectName=' +
                                     encodeURIComponent(proj.ProjectName);
-                            location.hash = projectId;
+                            location.hash = 'present:' + projectId;
                         }
                     },
                     myself.ide.cloudError()


### PR DESCRIPTION
This makes it so that `#project:` correctly appears in shared urls, reported in #915 

Not sure how that got left out :(