### PR TITLE
Prevent anti-aliasing when merging canvases in paint editor

### DIFF
--- a/paint.js
+++ b/paint.js
@@ -57,6 +57,7 @@
     June 4 - tweaks (Jens)
     Aug 24 - floodfill alpha-integer issue (Kartik)
     Sep 29 - tweaks (Jens)
+    Sep 28 [of the following year :)] - Try to prevent antialiasing (Kartik)
  */
 
 /*global Point, Rectangle, DialogBoxMorph, fontHeight, AlignmentMorph,
@@ -595,6 +596,7 @@ PaintCanvasMorph.prototype.scale = function (x, y) {
         this.rotationCenter.y
     );
     c.getContext("2d").scale(1 + x, 1 + y);
+    this.disableSmoothing(c.getContext("2d"));
     c.getContext("2d").drawImage(
         this.paper,
         -this.rotationCenter.x,
@@ -622,11 +624,21 @@ PaintCanvasMorph.prototype.undo = function () {
     }
 };
 
+PaintCanvasMorph.prototype.disableSmoothing = function(ctx) {
+    ctx['imageSmoothingEnabled'] = false;       /* standard */
+    ctx['mozImageSmoothingEnabled'] = false;    /* Firefox */
+    ctx['oImageSmoothingEnabled'] = false;      /* Opera */
+    ctx['webkitImageSmoothingEnabled'] = false; /* Safari */
+    ctx['msImageSmoothingEnabled'] = false;     /* IE */
+};
+
 PaintCanvasMorph.prototype.merge = function (a, b) {
+    this.disableSmoothing(b.getContext("2d"));
     b.getContext("2d").drawImage(a, 0, 0);
 };
 
 PaintCanvasMorph.prototype.centermerge = function (a, b) {
+    this.disableSmoothing(b.getContext("2d"));
     b.getContext("2d").drawImage(
         a,
         (b.width - a.width) / 2,
@@ -813,6 +825,9 @@ PaintCanvasMorph.prototype.mouseMove = function (pos) {
     this.brushBuffer.push([p, q]);
     mctx.lineWidth = this.settings.linewidth;
     mctx.clearRect(0, 0, this.bounds.width(), this.bounds.height()); // mask
+
+    // Antialiasing trick.
+    mctx.translate(0.5, 0.5);
 
     this.dragRect.corner = relpos.subtract(this.dragRect.origin); // reset crn
 


### PR DESCRIPTION
Now, when you un-zoom and zoom repeatedly, lines don't turn into fuzzy ghosts. Vertical and horizontal lines are pure n-pixel-wide and of $COLOR instead of n+1-pixel-wide and faded.

See also: http://stackoverflow.com/questions/195262/can-i-turn-off-antialiasing-on-an-html-canvas-element.