### PR TITLE
Handling of diacritics , [Alt] + key in input fields

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -4515,7 +4515,7 @@ CursorMorph.prototype.processKeyPress = function (event) {
         return null;
     }
     if (event.keyCode) { // Opera doesn't support charCode
-        if (event.ctrlKey) {
+        if (event.ctrlKey && (!event.altKey)) {
             this.ctrl(event.keyCode, event.shiftKey);
         } else if (event.metaKey) {
             this.cmd(event.keyCode, event.shiftKey);
@@ -4526,7 +4526,7 @@ CursorMorph.prototype.processKeyPress = function (event) {
             );
         }
     } else if (event.charCode) { // all other browsers
-        if (event.ctrlKey) {
+        if (event.ctrlKey && (!event.altKey)) {
             this.ctrl(event.charCode, event.shiftKey);
         } else if (event.metaKey) {
             this.cmd(event.charCode, event.shiftKey);
@@ -4545,7 +4545,7 @@ CursorMorph.prototype.processKeyDown = function (event) {
     // this.inspectKeyEvent(event);
     var shift = event.shiftKey;
     this.keyDownEventUsed = false;
-    if (event.ctrlKey) {
+    if (event.ctrlKey && (!event.altKey)) {
         this.ctrl(event.keyCode, event.shiftKey);
         // notify target's parent of key event
         this.target.escalateEvent('reactToKeystroke', event);
@@ -10345,7 +10345,7 @@ WorldMorph.prototype.initEventListeners = function () {
                 }
                 event.preventDefault();
             }
-            if ((event.ctrlKey || event.metaKey) &&
+            if ((event.ctrlKey && (!event.altKey) || event.metaKey) &&
                     (event.keyCode !== 86)) { // allow pasting-in
                 event.preventDefault();
             }


### PR DESCRIPTION
Workaround for diacritics handling in browser #4. Sequences [Ctrl] + key should be processed only when [Alt] is not pressed. 
Root of this problem is browsers javascript KeyboardEvent. Sequence [Alt] + key , generates [Alt] + [Ctrl] + key event. In "morphic.js" this is mishandled as [Ctrl] + key and prematurely disposed. To prevent this, test for "ctrlKey" should be expressed as "event.ctrlKey && (!event.altKey)".

This fix effectively disables [Ctrl] [Alt] + anything (acts as [Alt]...) in favor of proper handling of diacritics.

Works with Chrome, Opera, Internet Explorer, Edge on Windows 10.