### PR TITLE
Fix isAutoFill to allow false values

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -233,7 +233,7 @@ IDE_Morph.prototype.init = function (isAutoFill) {
     this.corralBar = null;
     this.corral = null;
 
-    this.isAutoFill = isAutoFill || true;
+    this.isAutoFill = isAutoFill === undefined ? true : isAutoFill;
     this.isAppMode = false;
     this.isSmallStage = false;
     this.filePicker = null;


### PR DESCRIPTION
currently the expression isAutoFill || true will always evaluate
to true! :O

(That makes the argument somewhat useless though.) So, this fixes things...