### PR TITLE
Automatic sprite center detection

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -6330,11 +6330,10 @@ Costume.prototype.shrinkWrap = function () {
     this.version = Date.now();
 };
 
-Costume.prototype.boundingBox = function () {
+Costume.prototype.canvasBoundingBox = function (pic) {
     // answer the rectangle surrounding my contents' non-transparent pixels
     var row,
         col,
-        pic = this.contents,
         w = pic.width,
         h = pic.height,
         ctx = pic.getContext('2d'),
@@ -6390,6 +6389,10 @@ Costume.prototype.boundingBox = function () {
 
     return new Rectangle(getLeft(), getTop(), getRight(), getBottom());
 };
+
+Costume.prototype.boundingBox = function () {
+    return this.canvasBoundingBox(this.contents);
+}
 
 // Costume duplication
 

--- a/paint.js
+++ b/paint.js
@@ -595,7 +595,7 @@ PaintCanvasMorph.prototype.init = function (shift) {
 // Calculate the center of all the non-transparent pixels on the canvas.
 PaintCanvasMorph.prototype.calculateCanvasCenter = function(canvas) {
     var canvasBounds = Costume.prototype.canvasBoundingBox(canvas);
-    if (canvasBounds == null) {
+    if (canvasBounds === null) {
         return null;
     }
     // Can't use canvasBounds.center(), it rounds down.

--- a/paint.js
+++ b/paint.js
@@ -592,84 +592,9 @@ PaintCanvasMorph.prototype.init = function (shift) {
     this.buildContents();
 };
 
-// Returns a rectangle that encloses all the non-transparent pixels on the canvas.
-PaintCanvasMorph.prototype.calculateCanvasBounds = function(canvas) {
-    var context = canvas.getContext("2d");
-    var imageData = context.getImageData(0, 0, canvas.width, canvas.height);
-    var imageDataBuffer = imageData.data;
-
-    var minX = canvas.width, minY = canvas.height, maxX = 0, maxY = 0;
-
-    // Scan to find the top border.
-    for (var y = 0; y < minY; y++) {
-        for (var x = 0; x < canvas.width; x++) {
-            var alphaValue = imageDataBuffer[(y * canvas.width + x) * 4 + 3];
-            if (alphaValue > 0) {
-                if (x < minX) {
-                    minX = x;
-                }
-                if (x > maxX) {
-                    maxX = x;
-                }
-                minY = y;
-                // Don't break yet, we must finish the row.
-            }
-        }
-    }
-
-    if (minY == canvas.height) {
-        // Early exit: no opaque pixels.
-        return null;
-    }
-
-    // Scan to find the bottom border
-    maxY = minY;
-    for (var y = canvas.height - 1; y > maxY; y--) {
-        for (var x = 0; x < canvas.width; x++) {
-            var alphaValue = imageDataBuffer[(y * canvas.width + x) * 4 + 3];
-            if (alphaValue > 0) {
-                if (x < minX) {
-                    minX = x;
-                }
-                if (x > maxX) {
-                    maxX = x;
-                }
-                maxY = y;
-                // Don't break yet, we must finish the row.
-            }
-        }
-    }
-
-    // Scan to find the left border
-    for (var x = 0; x < minX; x++) {
-        for (var y = minY + 1; y < maxY; y++) {
-            var alphaValue = imageDataBuffer[(y * canvas.width + x) * 4 + 3];
-            if (alphaValue > 0) {
-                minX = x;
-                // Break now, no need to finish the column.
-                break;
-            }
-        }
-    }
-
-    // Finally find the right border
-    for (var x = canvas.width - 1; x > maxX; x--) {
-        for (var y = minY + 1; y < maxY; y++) {
-            var alphaValue = imageDataBuffer[(y * canvas.width + x) * 4 + 3];
-            if (alphaValue > 0) {
-                maxX = x;
-                // Break now, no need to finish the column.
-                break;
-            }
-        }
-    }
-
-    return new Rectangle(minX, minY, maxX + 1, maxY + 1);
-};
-
 // Calculate the center of all the non-transparent pixels on the canvas.
 PaintCanvasMorph.prototype.calculateCanvasCenter = function(canvas) {
-    var canvasBounds = this.calculateCanvasBounds(canvas);
+    var canvasBounds = Costume.prototype.canvasBoundingBox(canvas);
     if (canvasBounds == null) {
         return null;
     }


### PR DESCRIPTION
This change allows the paint editor to automatically decide where the center of the sprite is. For example, just drawing a smiley face and then selecting the cross-hairs tool will result in the following:
![example](https://cloud.githubusercontent.com/assets/4537985/11657324/18fb02b8-9e10-11e5-8f19-d4d2fbd9337b.png)
Once the cross-hairs tool is selected and moved, then the paint editor will no longer continue updating the sprite centre. This allows the user to select any center point, as usual.

When users are unaware of the center point feature, they often complain that their sprites are not appearing where the object really is, leading to much confusion.

This feature also makes the flipping process more natural:
![start](https://cloud.githubusercontent.com/assets/4537985/11657477/1a90b540-9e11-11e5-98aa-e88d1d2c90ab.png)
will become
![goodflip](https://cloud.githubusercontent.com/assets/4537985/11657485/21ad002c-9e11-11e5-8ef1-17c204ebf78f.png)
rather than
![badflip](https://cloud.githubusercontent.com/assets/4537985/11657490/288a8fae-9e11-11e5-91b2-aea6fd05dc90.png)
after this change.