### PR TITLE
Add native C&P support to morphic text inputs!

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -4496,19 +4496,18 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
         this.target.setAlignmentToLeft();
     }
     this.gotoSlot(this.slot);
-    
+
     // Add hidden text box for copying and pasting
     this.hiddenText = document.createElement('textarea');
-    this.target.hiddenText = this.hiddenText;
     this.hiddenText.style.position = 'absolute';
     this.hiddenText.style.right = '101%'; // placed just out of view
-    
+
     document.body.appendChild(this.hiddenText);
-    
+
     this.hiddenText.value = this.target.selection();
     this.hiddenText.focus();
     this.hiddenText.select();
-    
+
     this.hiddenText.addEventListener(
         'keypress',
         function (event) {
@@ -4518,7 +4517,7 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
         },
         false
     );
-    
+
     this.hiddenText.addEventListener(
         'keydown',
         function (event) {

--- a/morphic.js
+++ b/morphic.js
@@ -4478,7 +4478,7 @@ function CursorMorph(aStringOrTextMorph) {
 }
 
 CursorMorph.prototype.init = function (aStringOrTextMorph) {
-    var ls;
+    var ls, myself = this;
 
     // additional properties:
     this.keyDownEventUsed = false;
@@ -4496,6 +4496,59 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
         this.target.setAlignmentToLeft();
     }
     this.gotoSlot(this.slot);
+    
+    // Add hidden text box for copying and pasting
+    this.hiddenText = document.createElement('textarea');
+    this.target.hiddenText = this.hiddenText;
+    this.hiddenText.style.position = 'absolute';
+    this.hiddenText.style.right = '101%'; // placed just out of view
+    
+    document.body.appendChild(this.hiddenText);
+    
+    this.hiddenText.value = this.target.selection();
+    this.hiddenText.focus();
+    this.hiddenText.select();
+    
+    this.hiddenText.addEventListener(
+        'keypress',
+        function (event) {
+            console.log('press');
+            console.log(event);
+            myself.processKeyPress(event);
+            this.value = myself.target.selection();
+            this.select();
+        },
+        false
+    );
+    
+    this.hiddenText.addEventListener(
+        'keydown',
+        function (event) {
+            console.log('down');
+            console.log(event);
+            myself.processKeyDown(event);
+            this.value = myself.target.selection();
+            this.select();
+            
+            // Make sure tab prevents default
+            if (event.keyIdentifier === 'U+0009' || event.keyIdentifier === 'Tab') {
+                myself.processKeyPress(event);
+                event.preventDefault();
+            }
+        },
+        false
+    );
+    
+    this.hiddenText.addEventListener(
+        'input',
+        function (event) {
+            if (this.value === '') {
+                myself.gotoSlot(myself.target.selectionStartSlot());
+                myself.target.deleteSelection();
+            }
+        },
+        false
+    );
 };
 
 // CursorMorph event processing:
@@ -4848,6 +4901,9 @@ CursorMorph.prototype.destroy = function () {
         this.target.alignment = this.originalAlignment;
         this.target.drawNew();
         this.target.changed();
+    }
+    if (this.hiddenText) {
+        document.body.removeChild(this.hiddenText);
     }
     CursorMorph.uber.destroy.call(this);
 };

--- a/morphic.js
+++ b/morphic.js
@@ -4527,7 +4527,8 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
             this.select();
             
             // Make sure tab prevents default
-            if (event.keyIdentifier === 'U+0009' || event.keyIdentifier === 'Tab') {
+            if (event.keyIdentifier === 'U+0009' ||
+                    event.keyIdentifier === 'Tab') {
                 myself.processKeyPress(event);
                 event.preventDefault();
             }

--- a/morphic.js
+++ b/morphic.js
@@ -4512,8 +4512,6 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
     this.hiddenText.addEventListener(
         'keypress',
         function (event) {
-            console.log('press');
-            console.log(event);
             myself.processKeyPress(event);
             this.value = myself.target.selection();
             this.select();
@@ -4524,8 +4522,6 @@ CursorMorph.prototype.init = function (aStringOrTextMorph) {
     this.hiddenText.addEventListener(
         'keydown',
         function (event) {
-            console.log('down');
-            console.log(event);
             myself.processKeyDown(event);
             this.value = myself.target.selection();
             this.select();


### PR DESCRIPTION
All the hard work goes to the folks working on Edgy for this one!
@cyderize wrote Edgy's implementation, and I copied that almost exactly.

https://github.com/snapapps/edgy/blob/08f6c473aed6526202eaa84f82d4819e18ccbf05/edgy/clipboard.js

* In the current edgy implementation, there's a `hiddenDiv` which
contains the `hiddenText` textarea. I found that div to not be
necessary, so it was removed.
* I tweaked a couple `==` to be `===`.