### PR TITLE
Improve error handling in `length of`

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -1553,7 +1553,12 @@ Process.prototype.reportListLength = function (list) {
     if (list instanceof List) {
         return list.length();
     }
-    return list.length; // catch a common student error
+    if (list && list.hasOwnProperty('length')) {
+        return list.length; // catch a common student error
+    }
+    throw new Error(
+        'expecting a list as input, but received ' + this.reportTypeOf(list)
+    );
 };
 
 Process.prototype.reportListContainsItem = function (list, element) {


### PR DESCRIPTION
Immediate fix for #1071, tagging #1067

This makes the `length` check more robust,
and also adds a more helpful error message if you can't check
for length.