### PR TITLE
Allow exporting script pics with results that error

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -865,7 +865,8 @@ Process.prototype.handleError = function (error, element) {
         (m === element ? '' : 'Inside: ')
             + error.name
             + '\n'
-            + error.message
+            + error.message,
+        this.exportResult
     );
 };
 


### PR DESCRIPTION
The allows you to easily get a script pic of a block showing an error.