### PR TITLE
Fixed #1090

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -2733,11 +2733,10 @@ Morph.prototype.toggleVisibility = function () {
 // Morph full image:
 
 Morph.prototype.fullImageClassic = function () {
-    // why doesn't this work for all Morphs?
-    var fb = this.fullBounds(),
+    var fb = this.cachedFullBounds || this.fullBounds(), // use the cache since fullDrawOn() will
         img = newCanvas(fb.extent()),
         ctx = img.getContext('2d');
-    ctx.translate(-this.bounds.origin.x, -this.bounds.origin.y);
+    ctx.translate(-fb.origin.x, -fb.origin.y);
     this.fullDrawOn(img, fb);
     img.globalAlpha = this.alpha;
     return img;


### PR DESCRIPTION
Fixes #1090, a bug in Morph.fullImageClassic() where it uses the bounds instead of the fullBounds.