### PR TITLE
fixes #1239

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -3484,8 +3484,9 @@ BlockMorph.prototype.destroy = function () {
     this.allComments().forEach(function (comment) {
         comment.destroy();
     });
-    
-    if (this.topBlock() === this && this.activeProcess()) {
+
+    if (!this.parent || !this.parent.topBlock
+            && this.activeProcess()) {
         this.activeProcess().stop();
     }
 

--- a/blocks.js
+++ b/blocks.js
@@ -3484,6 +3484,11 @@ BlockMorph.prototype.destroy = function () {
     this.allComments().forEach(function (comment) {
         comment.destroy();
     });
+    
+    if (this.topBlock() === this && this.activeProcess()) {
+        this.activeProcess().stop();
+    }
+
     BlockMorph.uber.destroy.call(this);
 };
 


### PR DESCRIPTION
It works both when dropping and ``right-click → delete``-ing whole scripts and script parts.

The ``topBlock`` check is needed because otherwise deleting just a part of a script would result in its process stopping.