### PR TITLE
Added check that parent is RingMorph. Fixes #1416

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2430,7 +2430,7 @@ BlockMorph.prototype.userMenu = function () {
         }
         return menu;
     }
-    if (this.parentThatIsA(RingMorph)) {
+    if (this.parent.parentThatIsA(RingMorph)) {
         menu.addLine();
         menu.addItem("unringify", 'unringify');
         menu.addItem("ringify", 'ringify');
@@ -2583,7 +2583,7 @@ BlockMorph.prototype.ringify = function () {
 
 BlockMorph.prototype.unringify = function () {
     // remove a Ring around me, if any
-    var ring = this.parentThatIsA(RingMorph),
+    var ring = this.parent.parentThatIsA(RingMorph),
         top = this.topBlock(),
         scripts = this.parentThatIsA(ScriptsMorph),
         block,


### PR DESCRIPTION
When providing the "unringify" option, it was checking that
the given block has a parent that is a RingMorph. However,
`parentThatIsA` will return the given block if it is the given
type when, in this context, we don't want to check the target of
the ringification.

Also fixed TypeError when unringify-ing an empty RingMorph caused
by a similar issue w/ getting the containing ring of an empty RingMorph