### PR TITLE
Fixed #1428, an issue with preview the (empty) project placeholder.

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -5440,16 +5440,19 @@ ProjectDialogMorph.prototype.setSource = function (source) {
             if (myself.task === 'open') {
 
                 src = localStorage['-snap-project-' + item.name];
-                xml = myself.ide.serializer.parse(src);
 
-                myself.notesText.text = xml.childNamed('notes').contents
-                    || '';
-                myself.notesText.drawNew();
-                myself.notesField.contents.adjustBounds();
-                myself.preview.texture = xml.childNamed('thumbnail').contents
-                    || null;
-                myself.preview.cachedTexture = null;
-                myself.preview.drawNew();
+                if (src) {
+                    xml = myself.ide.serializer.parse(src);
+
+                    myself.notesText.text = xml.childNamed('notes').contents
+                        || '';
+                    myself.notesText.drawNew();
+                    myself.notesField.contents.adjustBounds();
+                    myself.preview.texture =
+                        xml.childNamed('thumbnail').contents || null;
+                    myself.preview.cachedTexture = null;
+                    myself.preview.drawNew();
+                }
             }
             myself.edit();
         };


### PR DESCRIPTION
Quick fix for #1428. The current code treats the "(empty)" placeholder the same as any other project and attempts to open it, leading to a parse error. This checks first and does nothing for invalid projects.