### PR TITLE
Automatic indentation for newlines following already indented lines in multiline inputs

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -5108,7 +5108,18 @@ CursorMorph.prototype.processKeyDown = function (event) {
         if ((this.target instanceof StringMorph) || shift) {
             this.accept();
         } else {
+            var cursor = this.target.root().cursor;
+            var oldSlot = cursor.slot;
+            cursor.goHome();
+            var line = this.target.text.slice(cursor.slot).split('\n')[0];
+            cursor.gotoSlot(oldSlot);
+
+            var indent = 0;
             this.insert('\n');
+            while (line[indent] === ' ') {
+                indent++;
+                this.insert(' ');
+            }
         }
         this.keyDownEventUsed = true;
         break;


### PR DESCRIPTION
Sorry for the long title!

[Here's a demo!](https://youtu.be/bXjRz2UaBrM) Note that newlines after an already indented line will be indented as well:

```
foo<enter>
<enter>
  bar<enter>
  <cursor>
```

It works for any multiline input, so for example, it also works for project description inputs:

![Project description demo](https://cloud.githubusercontent.com/assets/9948030/18875408/029eabb4-849c-11e6-9a8a-f640cf224106.png)

It's handy for writing long pieces of code. Right now you have to press space at least once for each level of indentation you want in your code.

It _does not_ behave like your text editor, which probably automatically indents things when you press enter after an opening curly brace, or de-indents when you add a closing curly brace, but I do think this is fairly helpful and it's simple enough it can be applied to any multiline text input.
