### PR TITLE
Fixed minor costume editing discrepancy

### DIFF
--- a/objects.js
+++ b/objects.js
@@ -6938,13 +6938,13 @@ Costume.prototype.edit = function (aWorld, anIDE, isnew, oncancel, onsubmit) {
         function (img, rc) {
             myself.contents = img;
             myself.rotationCenter = rc;
-            if (anIDE.currentSprite instanceof SpriteMorph) {
-                // don't shrinkwrap stage costumes
-                myself.shrinkWrap();
-            }
             myself.version = Date.now();
             aWorld.changed();
             if (anIDE) {
+                if (anIDE.currentSprite instanceof SpriteMorph) {
+                    // don't shrinkwrap stage costumes
+                    myself.shrinkWrap();
+                }
                 anIDE.currentSprite.wearCostume(myself);
                 anIDE.hasChangedMedia = true;
             }


### PR DESCRIPTION
Prior to this change, it was unclear whether `anIDE` was a required argument for the `edit` method of `Costume`. [This line](https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/blob/master/objects.js#L6947) seems to suggest that it is an optional argument; however, that cannot be the case since [this line](https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/blob/master/objects.js#L6941) will fail if `anIDE` is not provided.

This modification makes `anIDE` optional by moving the failing line within the check for `anIDE`.