### PR TITLE
Renamed 'Cancel' to 'Close'

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -2892,7 +2892,7 @@ IDE_Morph.prototype.importMedia = function (mediaType) {
     dialog.createLabel();
     dialog.addBody(frame);
     dialog.addButton('ok', 'Import');
-    dialog.addButton('cancel', 'Cancel');
+    dialog.addButton('cancel', 'Close');
 
     dialog.ok = function () {
         if (selectedIcon) {


### PR DESCRIPTION
This is a pretty minor suggestion about the labeling of the "Cancel" button when importing costumes.

"Cancel" seems to imply that the importing of the selected costumes will be canceled. Since the costume imports cannot be canceled, I thought "Close" was more clear as to the behavior of the button
