### PR TITLE
Fix extra inputs appearing when custtom blocks are deleted

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2546,9 +2546,10 @@ BlockMorph.prototype.deleteBlock = function () {
             }
         });
     }
-    if ((this.parent instanceof BlockMorph)
-            || (this.parent instanceof MultiArgMorph)
-            || (this.parent instanceof ReporterSlotMorph)) {
+    if (this instanceof ReporterBlockMorph &&
+			((this.parent instanceof BlockMorph)
+            	|| (this.parent instanceof MultiArgMorph)
+            	|| (this.parent instanceof ReporterSlotMorph))) {
         this.parent.revertToDefaultInput(this);
     } else { // CommandBlockMorph
         if (this.parent) {


### PR DESCRIPTION
Fixing #1553 

We need to amend [this change](https://github.com/jmoenig/Snap--Build-Your-Own-Blocks/commit/ff5f9a7601d1b37868ab6ccc5b79fd9b78362411#diff-5f5bb19933ecde89bb86b19173cdef9eL2531) made in October to improve Visible stepping feature.
It causes the appearance of extra inputs after custom block definitions deleting.

I have rewritten the reporterBlock condition.