### PR TITLE
Localization for 'undrop' and 'redrop' options

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -5722,7 +5722,7 @@ ScriptsMorph.prototype.userMenu = function () {
                         'turnBack',
                         MorphicPreferences.menuFontSize
                     ),
-                    'undrop'
+                    localize('undrop')
                 ],
                 'undrop',
                 'undo the last\nblock drop\nin this pane'
@@ -5736,7 +5736,7 @@ ScriptsMorph.prototype.userMenu = function () {
                         'turnForward',
                         MorphicPreferences.menuFontSize
                     ),
-                    'redrop'
+                    localize('redrop')
                 ],
                 'redrop',
                 'redo the last undone\nblock drop\nin this pane'


### PR DESCRIPTION
Hi,
Working in catalan translation I've seen new 'undrop' and 'redrop' options are not translatable. File lang-de.js are updated with these two strings, but code needs the explicit 'localize()' function.
Thanks!

Joan