### PR TITLE
Langs update

### DIFF
--- a/lang-ca.js
+++ b/lang-ca.js
@@ -1122,9 +1122,9 @@ SnapTranslator.dict.ca = {
     'Command\n(C-shape)':
         'Comanda\n(en forma de C)',
     'Any\n(unevaluated)':
-        'Qualsevol\n(sense evaluar)',
+        'Qualsevol\n(sense avaluar)',
     'Boolean\n(unevaluated)':
-        'Booleà\n(sense evaluar)',
+        'Booleà\n(sense avaluar)',
     'Single input.':
         'Entrada única.',
     'Default Value:':

--- a/lang-ca.js
+++ b/lang-ca.js
@@ -846,7 +846,7 @@ SnapTranslator.dict.ca = {
     'uncheck for round ends of lines':
         'desmarqueu per fer que\nels extrems de les línies\ndel llapis siguin arrodonides',
     'Inheritance support':
-        'Suport per a herència',
+        'Suport a l\'herència d\'objectes',
 
     // inputs
     'with inputs':
@@ -1904,8 +1904,6 @@ SnapTranslator.dict.ca = {
         'desmarqueu per deshabilitar\nel suport a l\'edició per teclat',
     'check to enable\nkeyboard editing support':
         'marqueu per habilitar\nel suport a l\'edició per teclat',
-    'Inheritance support':
-        'Suport a l\'herència d\'objectes',
     'uncheck to disable\nsprite inheritance features':
         'desmarqueu per deshabilitar les\nfuncionalitats relatives a l\'herència d\'objectes',
     'check for sprite\ninheritance features':
@@ -1924,8 +1922,6 @@ SnapTranslator.dict.ca = {
 		'captura de pantalla',
 	'stage image':
 		'imatge de l\'escenari',
-	'frames':
-		'frames',
 	'processes':
 		'processos',
 	'map %repRing over %l':

--- a/lang-pt.js
+++ b/lang-pt.js
@@ -1909,8 +1909,6 @@ SnapTranslator.dict.pt = {
         'Desassinalar para desactivar\na edição usando o teclado.',
     'check to enable\nkeyboard editing support':
         'Assinalar para activar\na edição usando o teclado.',
-    'Inheritance support':
-        'Suporte para herança',
     'uncheck to disable\nsprite inheritance features':
         'Desassinalar para desactivar\nfuncionalidades de herança de actores.',
     'check for sprite\ninheritance features':

--- a/lang-zh_CN.js
+++ b/lang-zh_CN.js
@@ -1,6 +1,6 @@
 /*
 
-    lang-zh.js
+    lang-zh_CN.js
 
     Simplified Chinese translation for SNAP!
 
@@ -166,7 +166,7 @@
 
 /*global SnapTranslator*/
 
-SnapTranslator.dict.zh = {
+SnapTranslator.dict.zh_CN = {
 
 /*
     Special characters: (see <http://0xcc.net/jsescape/>)

--- a/lang-zh_TW.js
+++ b/lang-zh_TW.js
@@ -1,6 +1,6 @@
 /*
 
-	lang-tw.js
+	lang-zh_TW.js
 
 	Traditional Chinese translation for SNAP!
 	SNAP 繁體中文翻譯版
@@ -167,7 +167,7 @@
 
 /*global SnapTranslator*/
 
-SnapTranslator.dict.tw = {
+SnapTranslator.dict.zh_TW = {
 
 /*
     Special characters: (see <http://0xcc.net/jsescape/>)

--- a/locale.js
+++ b/locale.js
@@ -229,7 +229,7 @@ SnapTranslator.dict.cs = {
         '2015-11-16'
 };
 
-SnapTranslator.dict.zh = {
+SnapTranslator.dict.zh_CN = {
     'language_name':
         '简体中文',
     'language_translator':
@@ -317,7 +317,7 @@ SnapTranslator.dict.pl = {
         '2016-11-14'
 };
 
-SnapTranslator.dict.tw = {
+SnapTranslator.dict.zh_TW = {
     'language_name':
         '繁體中文',
     'language_translator':


### PR DESCRIPTION
Hi!
I'm working in #1551, making some scripts for an easier translation synchronization (I hope tomorrow I'll share more info), and I found some things on the way...
  - We have 39 languages (38 lang-xx translations and English). Chinese lang_packs codes are not according to ISO standards. According with cch (Traditional Chinese translator), I've updated them: **zh_CN for "Simplified Chinese"** (displaying "简体中文") and **zh_TW for "Traditional Chinese"** (displaying "繁體中文").
  - I've deleted duplicate translation strings in Catalan and Portuguese. Now, I note **Snap has 800 translatable text strings**. 531 are noted in lang-de, 244 more added in lang-pt, and 25 more in lang-ca.

We continuous in #1551 for this sync...

Thanks,

Joan