### PR TITLE
Fixing ColorSlotMorphs behavior in Visible Stepping

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -3358,7 +3358,7 @@ Process.prototype.flashContext = function () {
             !(expr instanceof CommandSlotMorph) &&
             !this.context.isFlashing &&
             expr.world() &&
-			!(expr instanceof ColorSlotMorph)) {
+            !(expr instanceof ColorSlotMorph)) {
         this.unflash();
         expr.flash();
         this.context.isFlashing = true;

--- a/threads.js
+++ b/threads.js
@@ -3357,7 +3357,8 @@ Process.prototype.flashContext = function () {
             expr instanceof SyntaxElementMorph &&
             !(expr instanceof CommandSlotMorph) &&
             !this.context.isFlashing &&
-            expr.world()) {
+            expr.world() &&
+			!(expr instanceof ColorSlotMorph)) {
         this.unflash();
         expr.flash();
         this.context.isFlashing = true;


### PR DESCRIPTION
This PR fix #1499 

Visual Stepping flash ColorSlotMorph, and the execution of the block is with the wrong color (uses the "flashing color" and not slot/input color).
