### PR TITLE
fix typo in cachedInputs

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -2175,7 +2175,7 @@ BlockMorph.prototype.init = function (silently) {
 
     BlockMorph.uber.init.call(this, silently);
     this.color = new Color(0, 17, 173);
-    this.cashedInputs = null;
+    this.cachedInputs = null;
 };
 
 BlockMorph.prototype.receiver = function () {


### PR DESCRIPTION
This shouldn't affect anything, but now there won't be an extra (unused) property lying around.