### PR TITLE
Error Handling improvements

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -1575,26 +1575,26 @@ Process.prototype.reportNewList = function (elements) {
 };
 
 Process.prototype.reportCONS = function (car, cdr) {
-    // this.assertType(cdr, 'list');
+    this.assertType(cdr, 'list');
     return new List().cons(car, cdr);
 };
 
 Process.prototype.reportCDR = function (list) {
     if (!list) {return; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     return list.cdr();
 };
 
 Process.prototype.doAddToList = function (element, list) {
     if (!list) {return; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     list.add(element);
 };
 
 Process.prototype.doDeleteFromList = function (index, list) {
     var idx = index;
     if (index === '' || !list) {return; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     if (this.inputOption(index) === 'all') {
         return list.clear();
     }
@@ -1609,7 +1609,7 @@ Process.prototype.doDeleteFromList = function (index, list) {
 Process.prototype.doInsertInList = function (element, index, list) {
     var idx = index;
     if (index === '' || !list) {return; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length() + 1);
     }
@@ -1622,7 +1622,7 @@ Process.prototype.doInsertInList = function (element, index, list) {
 Process.prototype.doReplaceInList = function (index, list, element) {
     var idx = index;
     if (index === '' || !list) {return; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length());
     }
@@ -1635,7 +1635,7 @@ Process.prototype.doReplaceInList = function (index, list, element) {
 Process.prototype.reportListItem = function (index, list) {
     var idx = index;
     if (index === '' || !list) {return ''; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length());
     }
@@ -1647,13 +1647,13 @@ Process.prototype.reportListItem = function (index, list) {
 
 Process.prototype.reportListLength = function (list) {
     if (!list) {return 0; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     return list.length();
 };
 
 Process.prototype.reportListContainsItem = function (list, element) {
     if (!list) {return false; }
-    // this.assertType(list, 'list');
+    this.assertType(list, 'list');
     return list.contains(element);
 };
 

--- a/threads.js
+++ b/threads.js
@@ -2283,6 +2283,9 @@ Process.prototype.assertType = function (thing, typeString) {
     if (typeString instanceof Array && contains(typeString, thingType)) {
         return true;
     }
+    if (typeString instanceof Array) {
+        typeString = typeString.join(' or ');
+    }
     throw new Error('expecting ' + typeString + ' but getting ' + thingType);
 };
 

--- a/threads.js
+++ b/threads.js
@@ -1580,23 +1580,23 @@ Process.prototype.reportCONS = function (car, cdr) {
 };
 
 Process.prototype.reportCDR = function (list) {
+    if (!list) {return; }
     // this.assertType(list, 'list');
     return list.cdr();
 };
 
 Process.prototype.doAddToList = function (element, list) {
+    if (!list) {return; }
     // this.assertType(list, 'list');
     list.add(element);
 };
 
 Process.prototype.doDeleteFromList = function (index, list) {
     var idx = index;
+    if (index === '' || !list) {return; }
     // this.assertType(list, 'list');
     if (this.inputOption(index) === 'all') {
         return list.clear();
-    }
-    if (index === '') {
-        return null;
     }
     if (this.inputOption(index) === 'last') {
         idx = list.length();
@@ -1608,10 +1608,8 @@ Process.prototype.doDeleteFromList = function (index, list) {
 
 Process.prototype.doInsertInList = function (element, index, list) {
     var idx = index;
+    if (index === '' || !list) {return; }
     // this.assertType(list, 'list');
-    if (index === '') {
-        return null;
-    }
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length() + 1);
     }
@@ -1623,10 +1621,8 @@ Process.prototype.doInsertInList = function (element, index, list) {
 
 Process.prototype.doReplaceInList = function (index, list, element) {
     var idx = index;
+    if (index === '' || !list) {return; }
     // this.assertType(list, 'list');
-    if (index === '') {
-        return null;
-    }
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length());
     }
@@ -1638,10 +1634,8 @@ Process.prototype.doReplaceInList = function (index, list, element) {
 
 Process.prototype.reportListItem = function (index, list) {
     var idx = index;
+    if (index === '' || !list) {return ''; }
     // this.assertType(list, 'list');
-    if (index === '') {
-        return '';
-    }
     if (this.inputOption(index) === 'any') {
         idx = this.reportRandom(1, list.length());
     }
@@ -1652,11 +1646,13 @@ Process.prototype.reportListItem = function (index, list) {
 };
 
 Process.prototype.reportListLength = function (list) {
+    if (!list) {return 0; }
     // this.assertType(list, 'list');
     return list.length();
 };
 
 Process.prototype.reportListContainsItem = function (list, element) {
+    if (!list) {return false; }
     // this.assertType(list, 'list');
     return list.contains(element);
 };

--- a/threads.js
+++ b/threads.js
@@ -2585,16 +2585,11 @@ Process.prototype.reportUnicodeAsLetter = function (num) {
 
 Process.prototype.reportTextSplit = function (string, delimiter) {
     var types = ['text', 'number'],
-        strType = this.reportTypeOf(string),
-        delType = this.reportTypeOf(this.inputOption(delimiter)),
         str,
         del;
-    if (!contains(types, strType)) {
-        throw new Error('expecting text instead of a ' + strType);
-    }
-    if (!contains(types, delType)) {
-        throw new Error('expecting a text delimiter instead of a ' + delType);
-    }
+    this.assertType(string, types);
+    this.assertType(this.inputOption(delimiter), types);
+
     str = isNil(string) ? '' : string.toString();
     switch (this.inputOption(delimiter)) {
     case 'line':

--- a/threads.js
+++ b/threads.js
@@ -171,6 +171,21 @@ function invoke(
     return proc.homeContext.inputs[0];
 }
 
+// SnapError ///////////////////////////////////////////////////////////
+/*
+    A SnapError is a wrapper around a standard JS Error message.
+    By throwing SnapError we can distinguish between our error messages
+    and ones from JS, which can be presented differently to users.
+*/
+function SnapError(message) {
+  this.name = 'Snap Error';
+  this.message = localize(message || 'An error has occurred.');
+  this.stack = (new Error()).stack;
+}
+
+SnapError.prototype = new Error();
+SnapError.prototype.constructor = SnapError;
+
 // ThreadManager ///////////////////////////////////////////////////////
 
 function ThreadManager() {


### PR DESCRIPTION
This turns on the assertions for list elements. Cue discussion on that...

Otherwise there are a couple other things:
* I have sane defaults for _not_ raising errors for the list primitives when no data is provided. This is the most "Scratch-like" IMO, and no-ops for the commands make sense because if you have null data it seems like you clicked the block rather than are trying to use it in a script. 
* improves the error display if you have a list of types by joining with ' or '
* Adds a new error `SnapError`. This isn't used yet, but my intention is for us to `throw new SnapError` instead of `throw new Error` which will also showing a message to distinguish between messages we write and JS errors, which we can preface with more verbose text. 
* has the split reporter use the assert method, instead of its own implementation. 