### PR TITLE
fixes #1349

### DIFF
--- a/paint.js
+++ b/paint.js
@@ -740,7 +740,7 @@ PaintCanvasMorph.prototype.floodfill = function (sourcepoint) {
         ctx = this.paper.getContext("2d"),
         img = ctx.getImageData(0, 0, width, height),
         data = img.data,
-        stack = [Math.round(sourcepoint.y) * width + sourcepoint.x],
+        stack = [Math.round(Math.round(sourcepoint.y) * width + sourcepoint.x)],
         currentpoint,
         read,
         sourcecolor,


### PR DESCRIPTION
It only happened in some browsers and in particular layouts due to the brilliant decision behind all JS numbers being floats. I guess some browsers round stuff up and others don't, thus 480 became 479.999998 in Firefox, where the mouse pointer position also had a fractional part, and since it couldn't detect the color of pixels in nonexistent float coordinates, the stack kept growing, forever looking for the next pixel.

All in all, I `Math.round`ed the position where the algorithm starts comparing pixel colors and that solved it.