### PR TITLE
Fixing toggle design bug in non English languages

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -489,6 +489,8 @@ IDE_Morph.prototype.openIn = function (world) {
         } else if (location.hash.substr(0, 7) === '#signup') {
             this.createCloudAccount();
         }
+    this.loadNewProject = false;
+
     }
 
     if (this.userLanguage) {


### PR DESCRIPTION
Hi all,

## Issue - Current behaviour
  - When I start Snap! with a **non English language** (language && language !== 'en') and I change the design (**toggling flat design on/off**), system **loads a new project (deleting all!!)**. Also (minor problem) IDE lines still remain in the previous style(design).
  - This issue remains until I change to another (any) language
## The origin
  - Snap! startup use **loadNewProject var** to ensure translation is complete (for example, sprite name was translated) in the startup.
  - Then, non English language have a initial _loadNewProject = true_ to do this.
  - But after startup, this var (_loadNewProject_) must be _false_. And it is not.
  - Then the problem is all _refreshIDE() calls_ load a new project (deleting previous without confirm message)
## Solution
  - **After startup** (at the end of the callback) I assign **loadNewProject = false** 