### PR TITLE
fixes #1799

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -8548,15 +8548,18 @@ StringMorph.prototype.mouseDoubleClick = function (pos) {
             slot -= 1;
         }
 
-        if (isWordChar(this.text[slot])) {
+        if (this.text[slot] && isWordChar(this.text[slot])) {
             this.selectWordAt(slot);
-        } else {
+        } else if (this.text[slot]) {
             this.selectBetweenWordsAt(slot);
+        } else {
+            // special case for when we click right after the
+            // last slot in multi line TextMorphs
+            this.selectAll();
         }
     } else {
         this.escalateEvent('mouseDoubleClick', pos);
     }
- 
 };
 
 StringMorph.prototype.selectWordAt = function (slot) {


### PR DESCRIPTION
Fixes the exception when double-clicking at the right of the last slot in a multi-line TextMorph.