### PR TITLE
Avoid flickering when resizing page

### DIFF
--- a/morphic.js
+++ b/morphic.js
@@ -11663,6 +11663,10 @@ WorldMorph.prototype.initEventListeners = function () {
         function () {
             if (myself.useFillPage) {
                 myself.fillPage();
+
+                // fillPage will resize worldCanvas, which clears it.
+                // so we redraw immediately, to prevent flickering
+                myself.updateBroken();
             }
         },
         false


### PR DESCRIPTION
_@brianharvey This is the bug we were talking about._

Brian and I were experiencing some rather upsetting flicker when resizing the window in Safari. This seems like a useful thing to fix, particularly for people who have problems with flickering!

Here's how resizing works:

1. The resize event triggers `fillPage()`, which resizes the `worldCanvas`. 
2. Some time later, the scheduler will redraw the screen (I believe this is handled in `updateBroken()`?)

The issue is that setting the width/height of a `<canvas>` implicitly clears it. Since we don't redraw until the next frame, the screen remains clear until then: causing a flicker of white page.