### PR TITLE
Fix reportURL for URLs that have // in the middle

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -2270,7 +2270,7 @@ Process.prototype.reportURL = function (url) {
     var response;
     if (!this.httpRequest) {
         // use the location protocol unless the user specifies otherwise
-        if (url.indexOf('//') < 0) {
+        if (url.indexOf('//') < 0 || url.indexOf('//') > 8) {
             if (location.protocol === 'file:') {
                 // allow requests from locally loaded sources
                 url = 'https://' + url;


### PR DESCRIPTION
Reported by @brianharvey.

When using proxies we often embed "https://" right in the middle of the URL. The reportURL block was mistakenly thinking that the protocol had already been added to the URL, thus trying to access a relative path.