### PR TITLE
Improve Unicode Blocks for Some Emoji

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -2688,7 +2688,7 @@ Process.prototype.reportStringSize = function (data) {
 };
 
 Process.prototype.reportUnicode = function (string) {
-    var str = (string || '\u0000').toString()[0];
+    var str = isNil(string) ? '\u0000' : string.toString();
 
     if (str.codePointAt) { // support for Unicode in newer browsers.
         return str.codePointAt(0);

--- a/threads.js
+++ b/threads.js
@@ -2688,12 +2688,20 @@ Process.prototype.reportStringSize = function (data) {
 };
 
 Process.prototype.reportUnicode = function (string) {
-    var str = (string || '').toString()[0];
-    return str ? str.charCodeAt(0) : 0;
+    var str = (string || '\u0000').toString()[0];
+
+    if (str.codePointAt) { // support for Unicode in newer browsers.
+        return str.codePointAt(0);
+    }
+    return str.charCodeAt(0);
 };
 
 Process.prototype.reportUnicodeAsLetter = function (num) {
     var code = +(num || 0);
+
+    if (String.fromCodePoint) { // support for Unicode in newer browsers.
+        String.fromCodePoint(code);
+    }
     return String.fromCharCode(code);
 };
 

--- a/threads.js
+++ b/threads.js
@@ -2700,7 +2700,7 @@ Process.prototype.reportUnicodeAsLetter = function (num) {
     var code = +(num || 0);
 
     if (String.fromCodePoint) { // support for Unicode in newer browsers.
-        String.fromCodePoint(code);
+        return String.fromCodePoint(code);
     }
     return String.fromCharCode(code);
 };


### PR DESCRIPTION
This makes the 🎃 work properly in the `unicode of` block.
Snap<em>!</em> now correctly reports '127875'.

~~However, `unicode (127875) as letter` still doesn't work quite right.~~
Fixed..was the missing return. D'oh!

Also I noticed edge cases in the `unicode of` block. Mostly around the values `false` and `0`. Minor, but I fixed that up.