### PR TITLE
Fixing #1932, csv spliter, according to RFC 4180 spec

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -2745,15 +2745,10 @@ Process.prototype.parseCSV = function (string) {
     // by lines.
     // Following RFC 4180 specifications
 
-    var re_valid = /^(?:"(?:(?:"{2})*[^"]*)*"|([^",]*))(?:,(?:"(?:(?:"{2})*[^"]*)*"|([^",]*)))*$/;
-    if (!re_valid.test(string)) {
-        return new List();
-    }
-
     var re_value = /(?:^|,)(?:"((?:(?:"{2})*[^"]*)*)"|([^",]*))(?=(?:,|$))/g,
         a = [];
 
-    string.replace(
+    var remaining = string.replace(
         re_value,
         function(m0, m1, m2) {
             if (m1 !== undefined) {
@@ -2766,6 +2761,10 @@ Process.prototype.parseCSV = function (string) {
             return '';
         }
     );
+    if (remaining !== '') {
+        // if remaining contains something, string has a non valid format
+        return new List();
+    }
     return new List(a);
 };
 


### PR DESCRIPTION
This fix #1932, bringing CSV spliting to [RFC 4180](https://tools.ietf.org/html/rfc4180) specifications and therefore, getting a full compatibility with spreadsheets exports.

Theses specifications are:
  - We have only one record, with fields separated by commas.
  - The last field in the record must not be followed by a comma. An end _comma_ means an extra empty field.
  - Spaces are considered part of a field and should not be ignored (they don't need text delimiters).
  - The only text delimiters are _double-quotes_. Single quote is plain text.
  - Fields with _double-quotes_ or _commas_ (as content) must be enclosed in double-quotes (as delimiters).
  - _Double-quotes_ content must be escaped by preceding it with another _double-quote_ [""].  There are not other escapers (nor [/"]).

It seems to be coherent with spreadsheet export operation (full tested with LibreOffice and a single test with Excel).