### PR TITLE
fixes #1889

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -3462,10 +3462,12 @@ BlockMorph.prototype.doRefactorGlobalVar = function (
                 true
             );
             stage.globalBlocks.forEach(function (eachBlock) {
-                eachBlock.body.expression.refactorVarInStack(
-                    oldName,
-                    newName
-                );
+                if (eachBlock.body) {
+                    eachBlock.body.expression.refactorVarInStack(
+                        oldName,
+                        newName
+                    );
+                }
             });
             stage.forAllChildren(function (child) {
                 if (child instanceof SpriteMorph) {


### PR DESCRIPTION
The error happened when a block editor with no body was open and we tried to refactor a variable. We need to guard against block editors where the body hasn't yet been built.