### PR TITLE
#1944 Always set fragment identifier on setURL()

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -4347,9 +4347,7 @@ IDE_Morph.prototype.openProject = function (name) {
 
 IDE_Morph.prototype.setURL = function (str) {
     // Set the URL to a project's XML contents
-    if (this.projectsInURLs) {
-        location.hash = str;
-    }
+    location.hash = this.projectsInURLs ? str : '';
 };
 
 IDE_Morph.prototype.saveFileAs = function (


### PR DESCRIPTION
Resolves #1944.

Ensures the fragment identifier is cleared out when performing "Save as" on a shared project and "Project URLs" is disabled (the default).