### PR TITLE
Typo in Catalan translation

### DIFF
--- a/lang-ca.js
+++ b/lang-ca.js
@@ -1578,7 +1578,7 @@ SnapTranslator.dict.ca = {
     'Logout':
         'Surt',
     'Change Password...':
-        'Canvia la contrassenya…',
+        'Canvia la contrasenya…',
     'Change Password':
         'Canvia la contrasenya',
     'Account created.':


### PR DESCRIPTION
"contra**ss**enya" should be "contra**s**enya"