### PR TITLE
Spanish translation update

### DIFF
--- a/lang-es.js
+++ b/lang-es.js
@@ -357,6 +357,12 @@ SnapTranslator.dict.es = {
     // shared messages:
     'development mode \ndebugging primitives:':
         'primitivas de depuraci\u00F3n\ndel modo desarrollador:',
+    'find blocks':
+        'buscar bloques',
+    'show primitives':
+        'mostrar primitivas',
+    'hide primitives':
+        'ocultar primitivas',
 
     // motion:
     'Stage selected:\nno motion primitives':
@@ -1007,10 +1013,19 @@ SnapTranslator.dict.es = {
     // variables:
     'Make a variable':
         'Crear una variable',
+    'Script variable name':
+        'Nombre de variable de programa',
     'Variable name':
         'Nombre de variable',
     'Delete a variable':
         'Borrar una variable',
+
+    'transient':
+        'excluir al guardar',
+    'uncheck to save contents\nin the project':
+        'desmarcar para guardar\nel contenido junto con el proyecto',
+    'check to prevent contents\nfrom being saved':
+        'marcar para no guardar\nel contenido junto con el proyecto',
 
     'set %var to %s':
         'fijar %var a %s',
@@ -1646,6 +1661,8 @@ SnapTranslator.dict.es = {
         'abre una nueva ventana\ncon una imagen de todos los programas',
     'make a block...':
         'crear bloque...',
+    'use the keyboard\nto enter blocks':
+        'usar el teclado\npara escribir bloques',
 
     // costumes
     'rename':

--- a/lang-es.js
+++ b/lang-es.js
@@ -383,21 +383,21 @@ SnapTranslator.dict.es = {
     'go to %dst':
         'ir a %dst',
     'glide %n secs to x: %n y: %n':
-        'deslizar %n segs a x: %n y: %n',
+        'deslizar en %n segs a x: %n y: %n',
     'change x by %n':
-        'cambiar x por %n',
+        'cambiar x en %n',
     'set x to %n':
         'fijar x a %n',
     'change y by %n':
-        'cambiar y por %n',
+        'cambiar y en %n',
     'set y to %n':
         'fijar y a %n',
     'if on edge, bounce':
-        'rebotar si est\u0061 tocando un borde',
+        'rebotar si toca un borde',
     'x position':
-        'posici\u00F3n en x',
+        'posici\u00F3n x',
     'y position':
-        'posici\u00F3n en y',
+        'posici\u00F3n y',
     'direction':
         'direcci\u00F3n',
 
@@ -429,13 +429,13 @@ SnapTranslator.dict.es = {
     'think %s':
         'pensar %s',
     'change %eff effect by %n':
-        'cambiar efecto %eff por %n',
+        'cambiar efecto %eff en %n',
     'set %eff effect to %n':
         'fijar efecto %eff a %n',
     'clear graphic effects':
         'quitar efectos gr\u00E1ficos',
     'change size by %n':
-        'cambiar tama\u00F1o por %n',
+        'cambiar tama\u00F1o en %n',
     'set size to %n %':
         'fijar tama\u00F1o a %n %',
     'size':
@@ -447,7 +447,7 @@ SnapTranslator.dict.es = {
     'go to front':
         'enviar al frente',
     'go back %n layers':
-        'enviar hacia atr\u00E1s %n capas',
+        'enviar %n capas hacia atr\u00E1s',
 
     // looks' development mode primitives:
     'wardrobe': // objects.js:401
@@ -455,7 +455,7 @@ SnapTranslator.dict.es = {
     'console log %mult%s':
         'registrar en consola %mult%s',
     'alert %mult%s':
-        'alerta %mult%s',
+        'mostrar mensaje %mult%s',
     'save %imgsource as costume named %s':
         'guardar %imgsource en disfraz %s',
 
@@ -503,9 +503,9 @@ SnapTranslator.dict.es = {
 
     // sound:
     'play sound %snd':
-        'tocar sonido %snd',
+        'reproducir sonido %snd',
     'play sound %snd until done':
-        'tocar sonido %snd y esperar',
+        'reproducir sonido %snd y esperar',
     'stop all sounds':
         'detener todos los sonidos',
     'rest for %n beats':
@@ -515,7 +515,7 @@ SnapTranslator.dict.es = {
     'set instrument to %inst':
         'fijar instrumento a %inst',
     'change tempo by %n':
-        'cambiar tempo por %n',
+        'cambiar tempo en %n',
     'set tempo to %n bpm':
         'fijar tempo a %n',
     'tempo':
@@ -551,15 +551,15 @@ SnapTranslator.dict.es = {
     'set pen color to %clr':
         'fijar color de l\u00E1piz a %clr',
     'change pen color by %n':
-        'cambiar color de l\u00E1piz por %n',
+        'cambiar color de l\u00E1piz en %n',
     'set pen color to %n':
         'fijar color de l\u00E1piz a %n',
     'change pen shade by %n':
-        'cambiar intensidad de l\u00E1piz por %n',
+        'cambiar brillo de l\u00E1piz en %n',
     'set pen shade to %n':
-        'fijar intensidad de l\u00E1piz a %n',
+        'fijar brillo de l\u00E1piz a %n',
     'change pen size by %n':
-        'cambiar tama\u00F1o de l\u00E1piz por %n',
+        'cambiar tama\u00F1o de l\u00E1piz en %n',
     'set pen size to %n':
         'fijar tama\u00F1o de l\u00E1piz a %n',
     'stamp':
@@ -587,7 +587,7 @@ SnapTranslator.dict.es = {
     'message':
         'mensaje',
     'warp %c':
-        'ejecutar en modo turbo %c',
+        'instrucci\u00F3n at\u00F3mica %c',
     'wait %n secs':
         'esperar %n segs',
     'wait until %b':
@@ -601,7 +601,7 @@ SnapTranslator.dict.es = {
     'if %b %c':
         'si %b %c',
     'if %b %c else %c':
-        'si %b %c si no %c',
+        'si %b %c sino %c',
     'report %s':
         'reportar %s',
     'stop %stopChoices':
@@ -1053,9 +1053,9 @@ SnapTranslator.dict.es = {
         'marcar para heredar de',
 
     'set %var to %s':
-        'fijar %var a %s',
+        'asignar a %var el valor %s',
     'change %var by %n':
-        'cambiar %var por %n',
+        'incrementar %var en %n',
     'show variable %var':
         'mostrar variable %var',
     'hide variable %var':
@@ -1073,17 +1073,17 @@ SnapTranslator.dict.es = {
     'list %exp':
         'lista %exp',
     '%s in front of %l':
-        '%s en frente de %l',
+        '%s delante de %l',
     'item %idx of %l':
         'elemento %idx de %l',
     'all but first of %l':
-        'todo menos la primera de %l',
+        '%l sin el primer elemento',
     'length of %l':
         'longitud de %l',
     '%l contains %s':
-        '%l contiene %s',
+        '\u00BF %l contiene %s ?',
     'add %s to %l':
-        'agregar %s a %l',
+        'a\u00F1adir %s a %l',
     'delete %ida of %l':
         'borrar %ida de %l',
     'insert %s at %idx of %l':

--- a/lang-es.js
+++ b/lang-es.js
@@ -1588,6 +1588,18 @@ SnapTranslator.dict.es = {
         'eliminar definici\u00F3n de bloque...',
     'edit...':
         'editar...',
+    'rename...':
+        'renombrar...',
+    'rename all...':
+        'renombrar todos...',
+    'translations...':
+        'traducciones...',
+    'block variables...':
+        'variables de bloque...',
+    'remove block variables...':
+        'eliminar variables de bloque...',
+    'experimental -\nunder construction':
+        'experimental\n(en construcci\u00F3n)',
 
     // sprites:
     'edit':
@@ -1642,6 +1654,12 @@ SnapTranslator.dict.es = {
         'exportar',
     'rename costume':
         'renombrar disfraz',
+
+    // input context menu
+    'options...':
+        'opciones...',
+    'read-only':
+        'solo lectura',
         
     // sounds
     'Play':
@@ -1699,8 +1717,6 @@ SnapTranslator.dict.es = {
         'Eliminar proyecto',
     'Are you sure you want to delete':
         '\u00BFEst\u00E1s seguro de que deseas eliminar',
-    'rename...':
-        'renombrar...',
     'Cloud':
         'Nube',
     'Browser':
@@ -1738,11 +1754,11 @@ SnapTranslator.dict.es = {
     'none':
         'ninguno',
 
-    // variable dialog
+    // variable dialog:
     'for all sprites':
         'para todos los objetos',
     'for this sprite only':
-        'para este objeto solamente',
+        's\u00F3lo para este objeto',
 
     // block dialog
     'Change block':
@@ -1752,13 +1768,21 @@ SnapTranslator.dict.es = {
     'Reporter':
         'Reportero',
     'Predicate':
-        'Condición',
+        'Predicado',
 
     // block editor
     'Block Editor':
         'Editor de bloques',
     'Apply':
         'Aplicar',
+    'block variables':
+        'variables de bloque',
+
+    // custom block translations dialog:
+    'Custom Block Translations':
+        'Traducciones del bloque personalizado',
+    'Enter one translation per line. use colon (":") as lang/spec delimiter\nand underscore ("_") as placeholder for an input, e.g.:\n\nen:say _ for _ secs':
+        'Escribe cada traducci\u00F3n en una l\u00EDnea.\nUtiliza (:) para separar el idioma y el mensaje\ny (_) para argumentos de entrada, por ejemplo:\n\n  es:decir _ durante _ segs',
 
     // block deletion dialog:
     'Delete Custom Block':
@@ -1766,47 +1790,58 @@ SnapTranslator.dict.es = {
     'block deletion dialog text':
         '\u00BFEst\u00E1s seguro de que quieres eliminar\neste bloque personalizado y todas sus instancias?',
 
-    // input dialog
+    // input dialog:
     'Create input name':
-        'Crear nombre de entrada',
+        'Crear par\u00E1metro',
     'Edit input name':
-        'Editar nombre de entrada',
+        'Editar par\u00E1metro',
     'Edit label fragment':
-        'Editar fragmento de etiqueta',
+        'Editar fragmento de texto',
     'Title text':
-        'Texto de t\u00EDtulo',
+        'Texto',
     'Input name':
-        'Ingresar nombre',
+        'Par\u00E1metro',
     'Delete':
         'Borrar',
+
     'Object':
         'Objeto',
-    'Number':
-        'N\u00FAmero',
     'Text':
         'Texto',
     'List':
         'Lista',
+    'Number':
+        'N\u00FAmero',
     'Any type':
         'Cualquier tipo',
     'Boolean (T/F)':
-        'Booleano (C/F)',
+        'Booleano (V/F)',
     'Command\n(inline)':
         'Comando\n(en l\u00EDnea)',
+    'Reporter':
+        'Reportero',
+    'Predicate':
+        'Predicado',
     'Command\n(C-shape)':
         'Comando\n(forma C)',
     'Any\n(unevaluated)':
-        'Cualquier\n(sin evaluar)',
+        'Cualquier tipo\n(no evaluado)',
     'Boolean\n(unevaluated)':
-        'Booleano\n(sin evaluar)',
+        'Booleano\n(no evaluado)',
+
     'Single input.':
-        'Entrada sola.',
+        'Entrada simple.',
     'Default Value:':
-        'Valor Predeterminado:',
+        'Valor predeterminado:',
     'Multiple inputs (value is list of inputs)':
-        'M\u00FAltiples entradas (valor es lista de insumos)',
+        'Entrada m\u00FAltiple (valores accesibles como lista)',
     'Upvar - make internal variable visible to caller':
-        'Hacer que la variable interna sea visible al llamador',
+        'Salida (hace visible una variable interna)',
+
+    'Input Slot Options':
+        'Opciones de par\u00E1metro de entrada',
+    'Enter one option per line.\nOptionally use "=" as key/value delimiter and {} for submenus. e.g.\n   the answer=42':
+        'Escribe cada opci\u00F3n en una l\u00EDnea.\nUsa "=" para asignar un valor y {} para submen\u00FAs, por ejemplo:\n  respuesta=42',
 
     // About Snap
     'About Snap':

--- a/lang-es.js
+++ b/lang-es.js
@@ -704,6 +704,32 @@ SnapTranslator.dict.es = {
     'Select a sound from the media library':
         'a\u00F1ade un sonido desde la biblioteca',
 
+    // cloud menu:
+    'Login...':
+        'Iniciar sesi\u00F3n...',
+    'Signup...':
+        'Registrarse...',
+    'Reset Password...':
+        'Reiniciar contrase\u00F1a...',
+    'Resend Verification Email...':
+        'Reenviar correo de verificaci\u00F3n...',
+
+    'Logout...':
+        'Cerrar sesi\u00F3n...',
+    'Change Password...':
+        'Cambiar contrase\u00F1a',
+
+    'url...':
+        'Url...',
+    'export project media only...':
+        'Exportar solamente medios del proyecto...',
+    'export project without media...':
+        'Exportar proyecto sin medios...',
+    'export project as cloud data...':
+        'Exportar proyecto como datos en la nube...',
+    'open shared project from cloud...':
+        'Abrir proyecto compartido en la nube...',
+
     // settings menu
     'Language...':
         'Idioma...',

--- a/lang-es.js
+++ b/lang-es.js
@@ -718,8 +718,8 @@ SnapTranslator.dict.es = {
     'Resend Verification Email...':
         'Reenviar correo de verificaci\u00F3n...',
 
-    'Logout...':
-        'Cerrar sesi\u00F3n...',
+    'Logout':
+        'Cerrar sesi\u00F3n',
     'Change Password...':
         'Cambiar contrase\u00F1a',
 

--- a/lang-es.js
+++ b/lang-es.js
@@ -398,8 +398,9 @@ SnapTranslator.dict.es = {
         'posici\u00F3n x',
     'y position':
         'posici\u00F3n y',
-    'direction':
-        'direcci\u00F3n',
+    // already defined
+    // 'direction':
+    //    'direcci\u00F3n',
 
     // %dir values for (point in direction %dir):
     '(90) right':
@@ -566,8 +567,9 @@ SnapTranslator.dict.es = {
         'sellar',
     'fill':
         'llenar',
-    'pen trails':
-        'rastro del l\u00E1piz',
+    // already defined
+    // 'pen trails':
+    //    'rastro del l\u00E1piz',
 
     // control:
     'when %greenflag clicked':
@@ -825,8 +827,9 @@ SnapTranslator.dict.es = {
         'puntero del rat\u00F3n',
     'edge':
         'borde del escenario',
-    'pen trails':
-        'rastro del l\u00E1piz',
+    // already defined
+    // 'pen trails':
+    //    'rastro del l\u00E1piz',
 
     // default value for (ask %s and wait):
     'what\'s your name?':
@@ -835,6 +838,7 @@ SnapTranslator.dict.es = {
     // %rel values for (%rel to %dst):
     'distance':
         'distancia',
+    // already defined
     'direction':
         'direcci\u00F3n',
 
@@ -1144,10 +1148,11 @@ SnapTranslator.dict.es = {
         'String',
     'Number':
         'n\u00FAmero',
-    'true':
-        'verdadero',
-    'false':
-        'falso',
+    // already defined
+    // 'true':
+    //     'verdadero',
+    // 'false':
+    //     'falso',
 
     // %codeKind values for (map %cmdRing to %codeKind %code)
     'code':
@@ -1156,8 +1161,9 @@ SnapTranslator.dict.es = {
         'cabecera',
 
     // %mapValue values for (map %mapValue to code %code):
-    'list':
-        'lista',
+    // already defined
+    // 'list':
+    //    'lista',
     'item':
         'elemento',
     'delimiter':
@@ -1258,13 +1264,15 @@ SnapTranslator.dict.es = {
     'Select categories of additional blocks to add to this project.':
         'a\u00F1ade bloques adicionales\npor categor\u00EDas a este proyecto',
 
-    'Costumes':
-        'Disfraces',
+    // already defined
+    // 'Costumes':
+    //    'Disfraces',
     'Select a costume from the media library':
         'a\u00F1ade un disfraz desde la biblioteca',
 
-    'Sounds':
-       'Sonidos',
+    // already defined
+    // 'Sounds':
+    //    'Sonidos',
     'Select a sound from the media library':
         'a\u00F1ade un sonido desde la biblioteca',
 
@@ -1714,8 +1722,9 @@ SnapTranslator.dict.es = {
         'ayuda...',
     'relabel...':
         'renombrar...',
-    'duplicate':
-        'duplicar',
+    // already defined
+    // 'duplicate':
+    //     'duplicar',
     'make a copy\nand pick it up':
         'crea una copia y\npermite moverla a otra parte',
     'only duplicate this block':
@@ -1815,8 +1824,9 @@ SnapTranslator.dict.es = {
     'open a new window\nwith a picture of the stage':
         'abre una nueva ventana\ncon una imagen del escenario',
 
-    'pen trails':
-        'rastro del l\u00E1piz',
+    // already defined
+    // 'pen trails':
+    //    'rastro del l\u00E1piz',
     'turn all pen trails and stamps\ninto a new costume for the\ncurrently selected sprite':
         'convierte todo rastro del l\u00E1piz\nen un nuevo disfraz para el objeto\nactualmente seleccionado',
     'turn all pen trails and stamps\ninto a new background for the stage':
@@ -1892,12 +1902,14 @@ SnapTranslator.dict.es = {
     'check to prevent contents\nfrom being saved':
         'marcar para no guardar\nel contenido junto con el proyecto',
 
-    'rename...':
-        'renombrar...',
+    // already defined
+    // 'rename...':
+    //     'renombrar...',
     'rename only\nthis reporter':
         'renombra s\u00F3lo\neste reportero',
-    'rename all...':
-        'renombrar todos...',
+    // already defined
+    // 'rename all...':
+    //     'renombrar todos...',
     'rename all blocks that\naccess this variable':
         'renombra todos los bloques\nque acceden a esta variable',
     'inherited':
@@ -1958,10 +1970,11 @@ SnapTranslator.dict.es = {
     'show a handle\nwhich can be dragged\nto change this morph\'s extent':
         'muestra una muesca que puede ser arrastrada\npara cambiar el tama\u00F1o de este morph',
 
-    'duplicate':
-        'duplicar',
-    'make a copy\nand pick it up':
-        'crea una copia y\npermite moverla a otro lugar',
+    // already defined
+    // 'duplicate':
+    //     'duplicar',
+    // 'make a copy\nand pick it up':
+    //     'crea una copia y\npermite moverla a otro lugar',
 
     'pick up':
         'coger',
@@ -1985,8 +1998,9 @@ SnapTranslator.dict.es = {
     'open a window on\nall properties':
         'abre una ventana\ncon todas las propiedades',
 
-    'pic...':
-        'imagen...',
+    // already defined
+    // 'pic...':
+    //     'imagen...',
     'open a new window\nwith a picture of this morph':
         'abre una nueva ventana\ncon una image de este morph',
 
@@ -2000,11 +2014,11 @@ SnapTranslator.dict.es = {
     'make this morph\nmovable':
         'permite que este morph\nse pueda mover',
 
-    'hide':
-        'ocultar',
-
-    'delete':
-        'eliminar',
+    // already defined
+    // 'hide':
+    //     'ocultar',
+    // 'delete':
+    //     'eliminar',
 
     'World...':
         'Mundo...',
@@ -2024,8 +2038,9 @@ SnapTranslator.dict.es = {
     'edit the costume\'s\nrotation center':
         'edita el centro\nde rotaci\u00F3n del disfraz',
 
-    'edit':
-        'editar',
+    // already defined
+    // 'edit':
+    //     'editar',
 
     'move all inside...':
         'mover todos dentro...',
@@ -2115,8 +2130,9 @@ SnapTranslator.dict.es = {
         'sombras difuminadas...',
     'blurry shades,\n use for new browsers':
         'sombras difuminadas\n(para navegadores modernos)',
-    'color...':
-        'color...',
+    // already defined
+    // 'color...':
+    //     'color...',
     'choose the World\'s\nbackground color':
         'selecciona el color\nde fondo del Mundo',
     'touch screen settings':
@@ -2143,8 +2159,9 @@ SnapTranslator.dict.es = {
         'caja',
     'circle box':
         'caja circular',
-    'slider':
-        'deslizador',
+    // already defined
+    // 'slider':
+    //     'deslizador',
     'dial':
         'disco',
     'frame':
@@ -2155,8 +2172,9 @@ SnapTranslator.dict.es = {
         'muesca',
     'string':
         'string',
-    'text':
-        'texto',
+    // already defined
+    // 'text':
+    //     'texto',
     'speech bubble':
         'mensaje popup',
     'gray scale palette':
@@ -2193,8 +2211,9 @@ SnapTranslator.dict.es = {
         'escenario normal',
     'turtle':
         'tortuga',
-    'stage':
-        'escenario',
+    // already defined
+    // 'stage':
+    //     'escenario',
     'turtleOutline':
         'tortuga (contorno)',
     'pause':
@@ -2221,16 +2240,18 @@ SnapTranslator.dict.es = {
         'rel\u00E1mpago',
     'brush':
         'pincel',
-    'rectangle':
-        'rect\u00E1ngulo',
+    // already defined
+    // 'rectangle':
+    //     'rect\u00E1ngulo',
     'rectangleSolid':
         'rect\u00E1ngulo (s\u00F3lido)',
     'circle':
         'c\u00EDrculo',
     'circleSolid':
         'c\u00EDrculo (s\u00F3lido)',
-    'line':
-        'l\u00EDnea',
+    // already defined
+    // 'line':
+    //     'l\u00EDnea',
     'cross':
         'cruz',
     'crosshairs':
@@ -2273,8 +2294,9 @@ SnapTranslator.dict.es = {
         'lupa (contorno)',
     'notes':
         'notas musicales',
-    'camera':
-        'c\u00E1mara',
+    // already defined
+    // 'camera':
+    //     'c\u00E1mara',
     'location':
         'ubicaci\u00F3n',
     'footprints':
@@ -2408,10 +2430,11 @@ SnapTranslator.dict.es = {
         'No se ha seleccionado ning\u00FAn bloque',
     'select':
         'seleccionar',
-    'all':
-        'todos',
-    'none':
-        'ninguno',
+    // already defined
+    // 'all':
+    //     'todos',
+    // 'none':
+    //     'ninguno',
 
     // variable dialog:
     'for all sprites':
@@ -2458,8 +2481,9 @@ SnapTranslator.dict.es = {
         'Texto',
     'Input name':
         'Par\u00E1metro',
-    'Delete':
-        'Eliminar',
+    // already defined
+    // 'Delete':
+    //     'Eliminar',
 
     'Object':
         'Objeto',
@@ -2467,18 +2491,20 @@ SnapTranslator.dict.es = {
         'Texto',
     'List':
         'Lista',
-    'Number':
-        'N\u00FAmero',
+    // already defined
+    // 'Number':
+    //     'N\u00FAmero',
     'Any type':
         'Cualquier tipo',
     'Boolean (T/F)':
         'Booleano (V/F)',
     'Command\n(inline)':
         'Comando\n(en l\u00EDnea)',
-    'Reporter':
-        'Reportero',
-    'Predicate':
-        'Predicado',
+    // already defined
+    // 'Reporter':
+    //     'Reportero',
+    // 'Predicate':
+    //     'Predicado',
     'Command\n(C-shape)':
         'Comando\n(tipo C)',
     'Any\n(unevaluated)':
@@ -2531,18 +2557,20 @@ SnapTranslator.dict.es = {
         'Parte de',
     'Parts':
         'Partes',
-    'Costumes':
-        'Disfraces',
-    'Sounds':
-        'Sonidos',
-    'Scripts':
-        'Programas',
+    // already defined
+    // 'Costumes':
+    //     'Disfraces',
+    // 'Sounds':
+    //     'Sonidos',
+    // 'Scripts':
+    //     'Programas',
     'For all Sprites':
         'Para todos los objetos',
     'Blocks':
         'Bloques',
-    'Variables':
-        'Variables',
+    // already defined
+    // 'Variables':
+    //     'Variables',
 
     // exported summary dialog
     'Could not export':

--- a/lang-es.js
+++ b/lang-es.js
@@ -704,7 +704,11 @@ SnapTranslator.dict.es = {
     'Select a sound from the media library':
         'a\u00F1ade un sonido desde la biblioteca',
 
-    // cloud menu:
+    // export project as... dialog
+    'Export Project As...':
+        'Exportar proyecto como...',
+
+    // cloud menu
     'Login...':
         'Iniciar sesi\u00F3n...',
     'Signup...':
@@ -729,6 +733,99 @@ SnapTranslator.dict.es = {
         'Exportar proyecto como datos en la nube...',
     'open shared project from cloud...':
         'Abrir proyecto compartido en la nube...',
+
+    // cloud url dialog
+    'Cloud URL':
+        'URL de la nube',
+    'Snap!Cloud':
+        'Snap!Cloud',
+    'localhost':
+        'localhost',
+    'localhost (secure)':
+        'localhost (seguro)',
+
+    // signup dialog
+    'Sign up':
+        'Registro',
+    'User name:':
+        'Nombre de usuario:',
+    'Birth date:':
+        'Fecha de nacimiento:',
+    'year:':
+        'a\u00F1o:',
+    'E-mail address:':
+        'Correo electr\u00F3nico:',
+    'Password:':
+        'Contrase\u00F1a:',
+    'Repeat Password:':
+        'Repetir contrase\u00F1a',
+    'Terms of Service...':
+        'T\u00E9rminos y condiciones de uso...',
+    'Privacy...':
+        'Privacidad...',
+    'I have read and agree\nto the Terms of Service':
+        'He le\u00EDdo y acepto los t\u00E9rminos\n y condiciones de uso',
+
+    'January':
+        'Enero',
+    'February':
+        'Febrero',
+    'March':
+        'Marzo',
+    'April':
+        'Abril',
+    'May':
+        'Mayo',
+    'June':
+        'Junio',
+    'July':
+        'Julio',
+    'August':
+        'Agosto',
+    'September':
+        'Septiembre',
+    'October':
+        'Octubre',
+    'November':
+        'Noviembre',
+    'December':
+        'Diciembre',
+    'or before':
+        'o antes',
+
+    // signin dialog
+    'Sign in':
+        'Iniciar sesi\u00F3n',
+    'stay signed in on this computer\nuntil logging out':
+        'Mantener la sesi\u00F3n iniciada en este ordenador',
+
+    // reset password dialog
+    'Reset password':
+        'Reiniciar contrase\u00F1a',
+
+    // resend verification email dialog
+    'Resend verification email':
+        'Reenviar correo de verificaci\u00F3n',
+
+    // change password dialog
+    'Change Password':
+        'Cambiar contrase\u00F1a',
+    'Old password:':
+        'Contrase\u00F1a actual:',
+    'New password:':
+        'Nueva contrase\u00F1a:',
+    'Repeat new password:':
+        'Repetir nueva contrase\u00F1a:',
+
+    // open shared project in cloud dialog
+    'Author name\u2026':
+        'Nombre del autor...',
+    'Project name...':
+        'Nombre del proyecto...',
+    'Fetching project\nfrom the cloud...':
+        'Descargando proyecto\ndesde la nube...',
+    'Opening project...':
+        'Abriendo proyecto...',
 
     // settings menu
     'Language...':
@@ -973,6 +1070,22 @@ SnapTranslator.dict.es = {
         'desmarcar para impedir guardar\nlas identidades de sublistas enlazadas',
     'check to enable\nsaving linked sublist identities':
         'marcar para permitir guardar\nlas identidades de sublistas enlazadas',
+
+    // zoom blocks dialog
+    'Zoom blocks':
+        'Agrandar bloques',
+
+    // stage size dialog
+    'Stage size':
+        'Tamaño del escenario',
+    'Stage width':
+        'Anchura del escenario',
+    'Stage height':
+        'Altura del escenario',
+
+    // dragging threshold dialog
+    'Dragging threshold':
+        'Umbral de arrastre',
 
     // inputs
     'with inputs':

--- a/lang-es.js
+++ b/lang-es.js
@@ -641,29 +641,69 @@ SnapTranslator.dict.es = {
         'Guardar',
     'Save As...':
         'Guardar como...',
+
     'Import...':
         'Importar...',
     'file menu import hint':
-        'men\u00FA de archivo de importaci\u00F3n indirecta',
-    'Export project as plain text...':
-        'Exportar proyecto como texto...',
+        'importa proyectos, bloques,\nim\u00E1genes o sonidos',
+
     'Export project...':
         'Exportar proyecto...',
+    '(in a new window)':
+        '(en una nueva ventana)',
+    'save project data as XML\nto your downloads folder':
+        'guarda el proyecto en XML\nen tu carpeta de descargas',
     'show project data as XML\nin a new browser window':
-        'mostrar informaci\u00F3n de proyecto como XML\nen una nueva ventana',
+        'muestra el proyecto en XML\nen una nueva ventana del navegador',
+
+    'Export project as plain text...':
+        'Exportar proyecto como texto...',
+
     'Export blocks...':
         'Exportar bloques...',
     'show global custom block definitions as XML\nin a new browser window':
-        'mostrar definiciones de bloques globales personalizados como XML\nen una nueva ventana',
-        'Export summary...':
-        'Resumen de exportación...',
+        'muestra definiciones de\nbloques personalizados en XML\nen una nueva ventana',
+
+    'Unused blocks...':
+        'Bloques no utilizados...',
+    'find unused global custom blocks\nand remove their definitions':
+        'busca bloques personalizados\nque no se est\u00E9n usando\ny borra sus definiciones',
+
+    'Export summary...':
+        'Exportar resumen...',
+    'open a new browser browser window\n with a summary of this project':
+        'muestra un resumen de este proyecto\nen una nueva ventana del navegador',
+
+    'Export summary with drop-shadows...':
+        'Exportar resumen (im\u00E1genes con sombra)...',
+    'open a new browser browser window\nwith a summary of this project\nwith drop-shadows on all pictures.\nnot supported by all browsers':
+        'muestra un resumen de este proyecto\ndonde las im\u00E1genes tienen sombra\nen una nueva ventana del navegador.\nno funciona en todos los navegadores',
+
+    'Export all scripts as pic...':
+        'Exportar todos los programas como imagen',
+    'show a picture of all scripts\nand block definitions':
+        'muestra una imagen con todos\nlos programas y definiciones de bloques',
+
     'Import tools':
-        'Herramientas de importaci\u00F3n',
+        'Importar herramientas',
     'load the official library of\npowerful blocks':
-        'cargar la biblioteca oficial de\nbloques potentes',
+        'carga la biblioteca oficial de\nbloques potentes',
+
     'Libraries...':
         'Bibliotecas...',
-        
+    'Select categories of additional blocks to add to this project.':
+        'a\u00F1ade bloques adicionales\npor categor\u00EDas a este proyecto',
+
+    'Costumes':
+        'Disfraces',
+    'Select a costume from the media library':
+        'a\u00F1ade un disfraz desde la biblioteca',
+
+    'Sounds':
+       'Sonidos',
+    'Select a sound from the media library':
+        'a\u00F1ade un sonido desde la biblioteca',
+
     // settings menu
     'Language...':
         'Idioma...',

--- a/lang-es.js
+++ b/lang-es.js
@@ -181,7 +181,7 @@ SnapTranslator.dict.es = {
     'language_name':
         'Espa\u00F1ol', // the name as it should appear in the language menu
     'language_translator':
-        'V\u00EDctor Manuel Muratalla Morales y Cristián Rizzi Iribarren', // your name for the Translators tab
+        'V\u00EDctor Manuel Muratalla Morales y Cristi\u00E1n Rizzi Iribarren', // your name for the Translators tab
     'translator_e-mail':
         'victor.muratalla@yahoo.com / rizzi.cristian@gmail.com', // optional
     'last_changed':
@@ -624,7 +624,7 @@ SnapTranslator.dict.es = {
     'with inputs':
         'con argumentos',
     'input names:':
-        'parámetros:',
+        'par\u00E1metros:',
     'Input Names:':
         'Nombres de entradas:',
     'input list:':
@@ -1184,7 +1184,7 @@ SnapTranslator.dict.es = {
     'Switch back to user mode':
         'Regresar a modo usuario',
     'disable deep-Morphic\ncontext menus\nand show user-friendly ones':
-        'desactiva los men\u0075s contextuales de Morphic\ny muestra unos más f\u00E1ciles de utilizar',
+        'desactiva los men\u0075s contextuales de Morphic\ny muestra unos m\u00E1s f\u00E1ciles de utilizar',
     'Switch to dev mode':
         'Cambiar a modo desarrollador',
     'enable Morphic\ncontext menus\nand inspectors,\nnot user-friendly!':
@@ -1574,7 +1574,7 @@ SnapTranslator.dict.es = {
     'Nested auto-wrapping':
         'Encapsular bloques internos',
     'uncheck to confine auto-wrapping\nto top-level block stacks':
-        'desmarcar para que bloques tipo C\nsólo puedan encapsular a otros m\u00E1s externos',
+        'desmarcar para que bloques tipo C\ns\u00F3lo puedan encapsular a otros m\u00E1s externos',
     'check to enable auto-wrapping\ninside nested block stacks':
         'marcar para permitir que bloques tipo C\npuedan encapsular a otros m\u00E1s internos',
 
@@ -1628,7 +1628,7 @@ SnapTranslator.dict.es = {
         '\u00A1EXPERIMENTAL! marcar para activar las\nestructuras de control personalizadas en vivo',
 
     'Thread safe scripts':
-        'Hilos de ejecución seguros',
+        'Hilos de ejecuci\u00F3n seguros',
     'uncheck to allow\nscript reentrance':
         'desmarcar para permitir\nla reentrada de programas',
     'check to disallow\nscript reentrance':
@@ -1671,7 +1671,7 @@ SnapTranslator.dict.es = {
 
     // zoom blocks dialog
     'Zoom blocks':
-        'Tamaño de bloque',
+        'Tama\u00F1o de bloque',
     'build':
         'construye',
     'your own':
@@ -2405,7 +2405,7 @@ SnapTranslator.dict.es = {
     'this project doesn\'t have any\ncustom global blocks yet':
         'este proyecto no tiene ning\u00FAn bloque personalizado todav\u00EDa',
     'no blocks were selected':
-        'No se ha seleccionado ningún bloque',
+        'No se ha seleccionado ning\u00FAn bloque',
     'select':
         'seleccionar',
     'all':
@@ -2510,7 +2510,7 @@ SnapTranslator.dict.es = {
     'Modules...':
         'M\u00F3dulos...',
     'Credits...':
-        'Créditos...',
+        'Cr\u00E9ditos...',
     'Translators...':
         'Traductores...',
     'License':

--- a/lang-es.js
+++ b/lang-es.js
@@ -1873,13 +1873,17 @@ SnapTranslator.dict.es = {
     'slider':
         'deslizador',
     'slider min...':
-        'valor m\u00EDnimo de deslizador...',
+        'm\u00EDnimo valor del deslizador...',
     'slider max...':
-        'valor m\u00E1ximo de deslizador...',
+        'm\u00E1ximo valor del deslizador...',
+    'import...':
+        'importar...',
+
+    // slider dialog:
     'Slider minimum value':
-        'valor m\u00EDnimo valor de deslizador',
+        'M\u00EDnimo valor del deslizador',
     'Slider maximum value':
-        'valor m\u00E1ximo valor de deslizador',
+        'M\u00E1ximo valor del deslizador',
 
     // list watchers
     'length: ':

--- a/lang-es.js
+++ b/lang-es.js
@@ -733,66 +733,246 @@ SnapTranslator.dict.es = {
     // settings menu
     'Language...':
         'Idioma...',
+    'Zoom blocks...':
+        'Agrandar bloques...',
+    'Stage size...':
+        'Tama\u00F1o del escenario...',
+
+    'Dragging threshold...':
+        'Umbral de arrastre...',
+    'specify the distance the hand has to move\nbefore it picks up an object':
+        'especifica cu\u00E1nto hay que arrastrar\nun objeto para comenzar a moverlo',
+
+    'Retina display support':
+        'Soporte para pantallas Retina',
+    'uncheck for lower resolution,\nsaves computing resources':
+        'desmarcar para una menor resoluci\u00F3n\n(ahorra recursos de computaci\u00F3n)',
+    'check for higher resolution,\nuses more computing resources':
+        'marcar para una mayor resoluci\u00F3n\n(usa m\u00E1s recursos de computaci\u00F3n)',
+
+    'Input sliders':
+        'Deslizadores en campos de entrada',
+    'uncheck to disable\ninput sliders for\nentry fields':
+        'desmarcar para desactivar\nlos deslizadores\nen los campos de entrada',
+    'check to enable\ninput sliders for\nentry fields':
+        'marcar para activar\nlos deslizadores\nen los campos de entrada',
+
+    'Execute on slider change':
+        'Ejecutar cuando un deslizador cambie',
+    'uncheck to suppress\nrunning scripts\nwhen moving the slider':
+        'desmarcar para no ejecutar el programa\ncuando se mueva el deslizador',
+    'check to run\nthe edited script\nwhen moving the slider':
+        'marcar para ejecutar el programa\ncuando se mueva el deslizador',
+
+    'Turbo mode':
+        'Modo turbo',
+    'uncheck to run scripts\nat normal speed':
+        'desmarcar para ejecutar\nlos programas a velocidad normal',
+    'check to prioritize\nscript execution':
+        'marcar para priorizar\nla ejecuci\u00F3n del programa',
+
+    'Visible stepping':
+        'Depuraci\u00F3n paso a paso',
+    'uncheck to turn off\nvisible stepping':
+        'desmarcar para desactivar\nla depuraci\u00F3n paso a paso',
+    'check to turn on\n visible stepping (slow)':
+        'marcar para activar\nla depuraci\u00F3n paso a paso (lento)',
+
+    'Ternary Boolean slots':
+        'Huecos booleanos triestado',
+    'uncheck to limit\nBoolean slots to true / false':
+        'desmarcar para restringir\nlos huecos booleanos a cierto / falso',
+    'check to allow\nempty Boolean slots':
+        'marcar para permitir\nhuecos booleanos vac\u00EDos',
+
+    'Camera support':
+        'Soporte para c\u00E1mara',
+    'uncheck to disable\ncamera support':
+        'desmarcar para desactivar\nel soporte de c\u00E1mara',
+    'check to enable\ncamera support':
+        'marcar para activar\nel soporte de c\u00E1mara',
+
     'Blurred shadows':
         'Sombras difuminadas',
     'uncheck to use solid drop\nshadows and highlights':
         'desmarcar para usar sombras\ny brillos s\u00F3lidos',
     'check to use blurred drop\nshadows and highlights':
         'marcar para usar sombras\ny brillos difuminados',
+
     'Zebra coloring':
         'Coloraci\u00F3n de cebra',
     'check to enable alternating\ncolors for nested blocks':
         'marcar para habilitar alternaci\u00F3n\nde colores para bloques anidados',
     'uncheck to disable alternating\ncolors for nested block':
         'desmarcar para inhabilitar alternaci\u00F3n\nde colores para bloques anidados',
+
     'Dynamic input labels':
         'Etiquetas de entrada din\u00E1micas',
     'uncheck to disable dynamic\nlabels for variadic inputs':
-        'desmarcar para inhabilitar etiquetas\ndin\u00E1micas para entradas vari\u00E1dicas',
+        'desmarcar para inhabilitar etiquetas\ndin\u00E1micas para entradas variables',
     'check to enable dynamic\nlabels for variadic inputs':
-        'marcar para habilitar etiquetas\ndin\u00E1micas para entradas vari\u00E1dicas',
+        'marcar para habilitar etiquetas\ndin\u00E1micas para entradas variables',
+
     'Prefer empty slot drops':
-        'Preferir ranuras de gotas vac\u00EDas',
+        'Dar preferencia a huecos vac\u00EDos',
     'settings menu prefer empty slots hint':
-        'men\u00FA de ajustes prefiere pistas de ranuras vac\u00EDas',
+        'marcar para impedir que los bloques puedan\nocupar el lugar de otros al ser soltados',
     'uncheck to allow dropped\nreporters to kick out others':
-        'desmarcar para permitir reporteros\nca\u00EDdos para echar a otros',
+        'desmarcar para permitir que los bloques puedan\nocupar el lugar de otros al ser soltados',
+
     'Long form input dialog':
-        'di\u00E1logo de entradas de forma larga',
-    'check to always show slot\ntypes in the input dialog':
-        'marcar para siempre mostrar tipos\nde espacios en el di\u00E1logo de insumo',
+        'Editor de par\u00E1metros extendido',
     'uncheck to use the input\ndialog in short form':
-        'desmarcar para usar el di\u00E1logo\nde insumo en forma corta',
+        'desmarcar para ocultar autom\u00E1ticamente\nlos tipos en el editor de par\u00E1metros',
+    'check to always show slot\ntypes in the input dialog':
+        'marcar para mostrar autom\u00E1ticamente\nlos tipos en el editor de par\u00E1metros',
+
+    'Plain prototype labels':
+        'Etiquetas planas',
+    'uncheck to always show (+) symbols\nin block prototype labels':
+        'desmarcar para mostrar los (+)\ndurante la definici\u00F3n de bloques',
+    'check to hide (+) symbols\nin block prototype labels':
+        'marcar para ocultar los (+)\ndurante la definici\u00F3n de bloques',
+
     'Virtual keyboard':
         'Teclado virtual',
     'uncheck to disable\nvirtual keyboard support\nfor mobile devices':
-        'desmarcar para inhabilitar\nsoporte al teclado virtual\npara dispositivos m\u00F3viles',
+        'desmarcar para inhabilitar\nel soporte del teclado virtual\npara dispositivos m\u00F3viles',
     'check to enable\nvirtual keyboard support\nfor mobile devices':
-        'marcar para habilitar\nsoporte para el teclado virtual\npara dispositivos m\u00F3viles',
-    'Input sliders':
-        'Deslizadores de insumo',
-    'uncheck to disable\ninput sliders for\nentry fields':
-        'desmarcar para inhabilitar\ndeslizadores de insumo para\ncampos de entrada',
-    'check to enable\ninput sliders for\nentry fields':
-        'marcar para habilitar\ndeslizadores de entrada para\ncampos de entrada',
+        'marcar para habilitar\nel soporte del teclado virtual\npara dispositivos m\u00F3viles',
+
     'Clicking sound':
         'Sonido de clic',
     'uncheck to turn\nblock clicking\nsound off':
-        'desmarcar para encender\nbloquear clic\napagar sonido',
+        'desmarcar para que no suene un "clic"\ncuando se coloca un bloque',
     'check to turn\nblock clicking\nsound on':
-        'marcar para encender\nbloque de clic\nencender sonido',
+        'marcar para que suene un "clic"\ncuando se coloca un bloque',
+
     'Animations':
         'Animaciones',
     'uncheck to disable\nIDE animations':
         'desmarcar para inhabilitar\nanimaciones del IDE',
     'check to enable\nIDE animations':
         'marcar para habilitar\nanimaciones del IDE',
+
+    'Cache Inputs':
+        'Cachear entradas',
+    'uncheck to stop caching\ninputs (for debugging the evaluator)':
+        'desmarcar para no cachear entradas\n(para depurar el evaluador)',
+    'check to cache inputs\nboosts recursion':
+        'marcar para cachear entradas\n(dispara la recusi\u00F3n)',
+
+    'Rasterize SVGs':
+        'Rasterizar SVGs',
+    'uncheck for smooth\nscaling of vector costumes':
+        'desmarcar para usar\nescalado suave en im\u00E1genes vectoriales',
+    'check to rasterize\nSVGs on import':
+        'marcar para rasterizar los SVGs\ntras haberlos importado',
+
+    'Flat design':
+        'Dise\u00F1o plano',
+    'uncheck for default\nGUI design':
+        'desmarcar para utilizar\nla interfaz predeterminada',
+    'check for alternative\nGUI design':
+        'marcar para utilizar\nla interfaz alternativa',
+
+    'Nested auto-wrapping':
+        'Encapsular bloques internos',
+    'uncheck to confine auto-wrapping\nto top-level block stacks':
+        'desmarcar para que bloques tipo C\nsolo puedan encapsular a otros m\u00E1s externos',
+    'check to enable auto-wrapping\ninside nested block stacks':
+        'marcar para permitir que bloques tipo C\npuedan encapsular a otros m\u00E1s internos',
+
+    'Project URLs':
+        'URLs de proyecto',
+    'uncheck to disable\nproject data in URLs':
+        'desmarcar para no incluir\ndatos de proyecto en las URLs',
+    'check to enable\nproject data in URLs':
+        'marcar para incluir\ndatos de proyecto en las URLs',
+
+    'Sprite Nesting':
+        'Anidamiento de objetos',
+    'uncheck to disable\nsprite composition':
+        'desmarcar para desactivar\nla composici\u00F3n de objetos',
+    'check to enable\nsprite composition':
+        'marcar para activar\nla composici\u00F3n de objetos',
+
+    'First-Class Sprites':
+        'Objetos de primera clase',
+    'uncheck to disable support\nfor first-class sprites':
+        'desmarcar para inhabilitar el\nsoporte para objectos de primera clase',
+    'check to enable support\n for first-class sprite':
+        'marcar para habilitar el\nsoporte para objectos de primera clase',
+
+    'Keyboard Editing':
+        'Edici\u00F3n de teclado',
+    'uncheck to disable\nkeyboard editing support':
+        'desmarcar para inhabilitar\nel soporte de edici\u00F3n de teclado',
+    'check to enable\nkeyboard editing support':
+        'marcar para habilitar\nel soporte de edici\u00F3n de teclado',
+
+    'Table support':
+        'Soporte para tablas',
+    'uncheck to disable\nmulti-column list views':
+        'desmarcar para no visualizar\nlistas multicolumna como tablas',
+    'check for multi-column\nlist view support':
+        'marcar para visualizar\nlistas multicolumna como tablas',
+
+    'Table lines':
+        'L\u00EDneas de tablas',
+    'uncheck for less contrast\nmulti-column list views':
+        'desmarcar para ver tablas\n con un menor contraste',
+    'check for higher contrast\ntable views':
+        'marcar para ver tablas\ncon un mayor contraste',
+
+    'Live coding support':
+        'Soporte para programaci\u00F3n en vivo',
+    'EXPERIMENTAL! uncheck to disable live\ncustom control structures':
+        '¡EXPERIMENTAL! desmarcar para inhabilitar las\nestructuras de control personalizadas en vivo',
+    'EXPERIMENTAL! check to enable\n live custom control structures':
+        '¡EXPERIMENTAL! marcar para habilitar las\nestructuras de control personalizadas en vivo',
+
     'Thread safe scripts':
         'Programas seguros para uso paralelo',
-    'uncheck to allow\nscript reentrancy':
-        'desmarcar para permitir\nreingreso de programa',
-    'check to disallow\nscript reentrancy':
-        'marcar para no permitir\nreingreso de programa',
+    'uncheck to allow\nscript reentrance':
+        'desmarcar para permitir\nla reentrada de programas',
+    'check to disallow\nscript reentrance':
+        'marcar para no permitir\nla reentrada de programas',
+
+    'Prefer smooth animations':
+        'Preferir animaciones suaves',
+    'uncheck for greater speed\nat variable frame rates':
+        'desmarcar para mayor velocidad\na cuadros por segundo variables',
+    'check for smooth, predictable\nanimations across computers':
+        'marcar para animaciones suaves y predecibles entre ordenadores',
+
+    'Flat line ends':
+        'Extremos de l\u00EDnea rectos',
+    'uncheck for round ends of lines':
+        'desmarcar para dibujar l\u00EDneas\ncon extremos redondeados',
+    'check for flat ends of lines':
+        'marcar para dibujar l\u00EDneas\ncon extremos rectos',
+
+    'Codification support':
+        'Soporte de codificaci\u00F3n',
+    'uncheck to disable\nblock to text mapping features':
+        'desmarcar para desactivar el soporte\nde conversi\u00F3n de bloques a c\u00F3digo',
+    'check for block\nto text mapping features':
+        'marcar para activar el soporte\nde conversi\u00F3n de bloques a c\u00F3digo',
+
+    'Inheritance support':
+        'Soporte de herencia',
+    'uncheck to disable\nsprite inheritance features':
+        'desmarcar para desactivar\nel soporte de herencia de objetos',
+    'check for sprite\ninheritance features':
+        'marcar para activar\nel soporte de herencia de objetos',
+
+    'Persist linked sublist IDs':
+        'IDs de sublistas enlazadas persistentes',
+    'uncheck to disable\nsaving linked sublist identities':
+        'desmarcar para impedir guardar\nlas identidades de sublistas enlazadas',
+    'check to enable\nsaving linked sublist identities':
+        'marcar para permitir guardar\nlas identidades de sublistas enlazadas',
 
     // inputs
     'with inputs':
@@ -1378,24 +1558,4 @@ SnapTranslator.dict.es = {
         'historieta',
     'confetti':
         'confite',
-
-    // under "Input sliders"
-    'Plain prototype labels':
-        'Etiquetas de prototipo planas',
-    'Turbo mode':
-        'Modo turbo',
-    'Flat design':
-        'Diseño plano',
-    'Keyboard Editing':
-        'Edición de teclado',
-    'Prefer smooth animations':
-        'Preferir animaciones suaves',
-    'Flat line ends':
-        'Bordes de línea planos',
-    'Codification support':
-        'Soporte de codificación',
-    'Inheritance support':
-        'Soporte de herencia',
-    'Zoom blocks...':
-        'Agrandar bloques...'
 };

--- a/lang-es.js
+++ b/lang-es.js
@@ -1080,9 +1080,41 @@ SnapTranslator.dict.es = {
     'thing':
         'cosa',
 
+    // table view dialog:
+    'Table view':
+        'Visor de tablas',
+
     // other
     'Make a block':
         'Crear un bloque',
+
+    // other development mode blocks:
+    'code of %cmdRing':
+        'c\u00F3digo de %cmdRing',
+    'map %cmdRing to %codeKind %code':
+        'mapear %cmdRing a %codeKind %code',
+    'map %mapValue to code %code':
+        'mapear %mapValue a c\u00F3digo %code',
+    'map %codeListPart of %codeListKind to code %code':
+        'mapear %codeListPart de %codeListKind a c\u00F3digo %code',
+
+    // %cmdRing values for (map %cmdRing to %codeKind %code):
+    'String':
+        'String',
+    'Number':
+        'n\u00FAmero',
+    'true':
+        'verdadero',
+    'false':
+        'falso',
+
+    // %mapValue values for (map %mapValue to code %code):
+    'list':
+        'lista',
+    'item':
+        'elemento',
+    'delimiter':
+        'delimitador',
 
     // menus
     // snap menu
@@ -1102,6 +1134,10 @@ SnapTranslator.dict.es = {
         'Cambiar a modo desarrollador',
     'enable Morphic\ncontext menus\nand inspectors,\nnot user-friendly!':
         'habilitar men\u0075s contextuales\n e inspectores de Morphic,\n\u00A1no son f\u00E1ciles de utilizar!',
+    'entering development mode.\n\nerror catching is turned off,\nuse the browser\'s web console\nto see error messages.':
+        'Se ha activado el modo desarrollador.\n\nEl cacheo de errores est\u00E1 desactivado,\nusa la consola del navegador\npara ver mensajes de error.',
+    'entering user mode':
+        'Se ha activado el modo usuario.',
 
     // project menu
     'Project notes...':
@@ -1180,6 +1216,14 @@ SnapTranslator.dict.es = {
     // export project as... dialog
     'Export Project As...':
         'Exportar proyecto como...',
+
+    // remove unused blocks dialog:
+    'Remove unused blocks':
+        'Borrar bloques no utilizados',
+    'there are currently no unused\nglobal custom blocks in this project':
+        'No hay bloques personalizados\nno utilizados en este proyecto',
+    'unused block(s) removed':
+        'bloque(s) no utilizado(s) eliminados',
 
     // cloud menu
     'Login...':
@@ -1547,6 +1591,26 @@ SnapTranslator.dict.es = {
     // zoom blocks dialog
     'Zoom blocks':
         'Agrandar bloques',
+    'build':
+        'construye',
+    'your own':
+        'tus propios',
+    'blocks':
+        'bloques',
+    'normal (1x)':
+        'normal (1x)',
+    'demo (1.2x)':
+        'demo (1.2x)',
+    'presentation (1.4x)':
+        'presentaci\u00F3n (1.4x)',
+    'big (2x)':
+        'grande (2x)',
+    'huge (4x)':
+        'inmenso (4x)',
+    'giant (8x)':
+        'gigantesco (8x)',
+    'monstrous (10x)':
+        'monstruoso (10x)',
 
     // stage size dialog
     'Stage size':
@@ -1728,6 +1792,10 @@ SnapTranslator.dict.es = {
         'Abrir',
     'Delete':
         'Eliminar',
+    'Share Project':
+        'Compartir',
+    'Unshare Project':
+        'Dejar de compartir',
     'Saved!':
         '\u00A1Guardado!',
     'Delete Project':
@@ -1740,6 +1808,20 @@ SnapTranslator.dict.es = {
         'Navegador',
     'Examples':
         'Ejemplos',
+    'last changed':
+        '\u00FAltima modificaci\u00F3n',
+    'Are you sure you want to share':
+        '\u00BFEst\u00E1s seguro de que\nquieres compartir',
+    'Are you sure you want to unshare':
+        '\u00BFEst\u00E1s seguro de que\nquieres dejar de compartir',
+    'sharing\nproject...':
+        'compartiendo proyecto...',
+    'shared.':
+        'compartido.',
+    'unsharing\nproject...':
+        'dejando de compartir...',
+    'unshared.':
+        'no compartido.',
 
     // costume editor
     'Costume Editor':
@@ -1909,6 +1991,34 @@ SnapTranslator.dict.es = {
     // coments
     'add comment here...':
         'añadir comentario aqu\u00ED...',
+
+    // exported summary
+    'Contents':
+        'Contenido',
+    'Kind of':
+        'Clase de',
+    'Part of':
+        'Parte de',
+    'Parts':
+        'Partes',
+    'Costumes':
+        'Disfraces',
+    'Sounds':
+        'Sonidos',
+    'Scripts':
+        'Programas',
+    'For all Sprites':
+        'Para todos los objetos',
+    'Blocks':
+        'Bloques',
+    'Variables':
+        'Variables',
+
+    // exported summary dialog
+    'Could not export':
+        'No se ha podido exportar',
+    'unable to export text':
+        'no se ha podido exportar el texto',
 
     //libraries
     'Tools':

--- a/lang-es.js
+++ b/lang-es.js
@@ -217,12 +217,20 @@ SnapTranslator.dict.es = {
         'Otro',
 
     // editor:
+    'don\'t rotate':
+        'no girar',
+    'can rotate':
+        'puede girar',
+    'only face left/right':
+        's\u00F3lo mirar a izquierda y derecha',
     'draggable':
         'arrastrable',
 
     // tabs:
     'Scripts':
         'Programas',
+    'Backgrounds':
+        'Fondos de escenario',
     'Costumes':
         'Disfraces',
     'Sounds':
@@ -233,25 +241,86 @@ SnapTranslator.dict.es = {
         'Objeto',
     'Stage':
         'Escenario',
+    'Turtle':
+        'Tortuga',
 
-    // rotation styles:
-    'don\'t rotate':
-        'no girar',
-    'can rotate':
-        'puede girar',
-    'only face left/right':
-        's\u00F3lo mirar izquierda/derecha',
+    // stage tab:
+    'Empty':
+        'Vac\u00EDo',
 
-    // new sprite button:
-    'add a new sprite':
-        'agregar un nuevo objeto',
-
-    // tab help
+    // costumes tab:
+    'Paint a new costume':
+        'dibujar un nuevo disfraz',
+    'Import a new costume from your webcam':
+        'importar un nuevo disfraz desde la c\u00E1mara',
     'costumes tab help':
-        'importar una foto de otro sitio Web o desde\n'
-            + 'su ordenador arrastr\u00E1ndolo hasta aqu\u00ED',
+        'Puedes importar un disfraz de otro sitio web\no desde tu ordenador arrastr\u00E1ndolo hasta aqu\u00ED',
+
+    // paint editor dialog:
+    'Paint Editor':
+        'Editor gr\u00E1fico',
+    'undo':
+        'deshacer',
+    'Paintbrush tool\n(free draw)':
+        'Pincel\n(dibujo libre)',
+    'Stroked Rectangle\n(shift: square)':
+        'Rect\u00E1ngulo\n(\u21E7 = cuadrado)',
+    'Stroked Ellipse\n(shift: circle)':
+        'Elipse\n(\u21E7 = c\u00EDrculo)',
+    'Eraser tool':
+        'Goma de borrar',
+    'Set the rotation center':
+        'Establecer centro de rotaci\u00F3n',
+    'Line tool\n(shift: vertical/horizontal)':
+        'L\u00EDnea\n(\u21E7 = vertical/horizontal)',
+    'Filled Rectangle\n(shift: square)':
+        'Rect\u00E1ngulo relleno\n(\u21E7 = cuadrado)',
+    'Filled Ellipse\n(shift: circle)':
+        'Elipse rellena\n(\u21E7 = c\u00EDrculo)',
+    'Fill a region':
+        'Bote de pintura',
+    'Pipette tool\n(pick a color anywhere)':
+        'Cuentagotas\n(obtiene colores de cualquier lugar)',
+    'grow':
+        'ampliar',
+    'shrink':
+        'reducir',
+    'flip \u2194':
+        'voltear \u2194',
+    'flip \u2195':
+        'voltear \u2195',
+    'Brush size':
+        'Tama\u00F1o de pincel',
+    'Constrain proportions of shapes?\n(you can also hold shift)':
+        'Figuras proporcionales\n(o mant\u00E9n pulsado \u21E7)',
+
+    // camera dialog:
+    'Camera':
+        'C\u00E1mara',
+    'Camera not supported':
+        'C\u00E1mara no soportada',
+    'Please make sure your web browser is up to date\nand your camera is properly configured. \n\nSome browsers also require you to access Snap!\nthrough HTTPS to use the camera.\n\nPlase replace the "http://" part of the address\nin your browser by "https://" and try again.':
+        'Por favor, comprueba que tu navegador est\u00E9 actualizado\ny tu c\u00E1mara configurada correctamente.\n\nAlgunos navegadores necesitan que accedas a Snap!\na trav\u00E9s de HTTPS para usar la c\u00E1mara.\n\nPor favor, reemplaza el "http://" en la barra de direcciones\nde tu navegador por "https://" y vuelve a intentarlo.',
+    'camera':
+        'c\u00E1mara',
+
+    // sound tab:
+    'Record a new sound':
+        'grabar un nuevo sonido',
     'import a sound from your computer\nby dragging it into here':
-        'importar un sonido desde su ordenador\narrastr\u00E1ndolo hasta aqu\u00ED',
+        'Puedes importar un sonido desde tu ordenador\narrastr\u00E1ndolo hasta aqu\u00ED',
+
+    // sound recorder dialog:
+    'Sound Recorder':
+        'Grabador de sonidos',
+
+    // stage & sprite corral:
+    'add a new Turtle sprite':
+        'a\u00F1adir una nueva tortuga',
+    'paint a new sprite':
+        'dibujar un nuevo objeto',
+    'take a camera snapshot and\nimport it as a new sprite':
+        'hacer una captura de c\u00E1mara\ne importarla como nuevo objeto',
 
     // primitive blocks:
 
@@ -1740,10 +1809,6 @@ SnapTranslator.dict.es = {
     // coments
     'add comment here...':
         'agregar comentario aqu\u00ED',
-
-    // costumes
-    'Turtle':
-        'Tortuga',
 
     //libraries
     'Tools':

--- a/lang-es.js
+++ b/lang-es.js
@@ -181,11 +181,11 @@ SnapTranslator.dict.es = {
     'language_name':
         'Espa\u00F1ol', // the name as it should appear in the language menu
     'language_translator':
-        'V\u00EDctor Manuel Muratalla Morales y Cristi\u00E1n Rizzi Iribarren', // your name for the Translators tab
+        'V\u00EDctor Manuel Muratalla Morales / Cristi\u00E1n Rizzi Iribarren / Alfonso Ruzafa', // your name for the Translators tab
     'translator_e-mail':
         'victor.muratalla@yahoo.com / rizzi.cristian@gmail.com', // optional
     'last_changed':
-        '2018-01-22', // this, too, will appear in the Translators tab
+        '2018-02-19', // this, too, will appear in the Translators tab
 
     // GUI
     // control bar:

--- a/lang-es.js
+++ b/lang-es.js
@@ -685,7 +685,7 @@ SnapTranslator.dict.es = {
         'muestra una imagen con todos\nlos programas y definiciones de bloques',
 
     'Import tools':
-        'Importar herramientas',
+        'Importar utilidades',
     'load the official library of\npowerful blocks':
         'carga la biblioteca oficial de\nbloques potentes',
 
@@ -1671,4 +1671,103 @@ SnapTranslator.dict.es = {
         'historieta',
     'confetti':
         'confite',
+
+    //libraries
+    'Tools':
+        'Utilidades',
+    'Standard library of powerful blocks (for, map, etc.)':
+        'Biblioteca est\u00E1ndar de bloques potentes (for, map, etc...)',
+
+    'Iteration, composition':
+        'Iteraci\u00F3n, composici\u00F3n',
+    'Traditional loop constructs (while, until, etc.) plus the Lisp "named let" (a generalization of FOR) plus functional iteration (repeated invocation of a function) and function composition.':
+        'Bucles tradicionales (while, until, etc...) + el "named let" de Lisp (una generalizaci\u00F3n del for) + iteraci\u00F3n funcional (invocaci\u00F3n repetida de una funci\u00F3n) y composici\u00F3n de funciones.',
+
+    'List utilities':
+        'Utilidades de lista',
+    'Some standard functions on lists (append, reverse, etc.)':
+        'Algunas funciones est\u00E1ndar de listas (append, reverse, etc...)',
+
+    'Streams (lazy lists)':
+        'Streams (listas perezosas)',
+    'A variation on the list data type in which each list item aren\'t computed until it\'s needed, so you can construct million-item lists without really taking up all that time or memory, or even infinite-sized lists.  (A block that reports all the prime numbers is included as an example.)':
+        'Una variaci\u00F3n del tipo de dato lista en el que cada elemento se calcula solo cuando es necesario, as\u00ED que puedes construir listas de un mill\u00F3n de elementos sin gastar tiempo o memoria, o incluso listas infinitas. (Un bloque que reporta todos los n\u00FAmeros primos viene incluido como ejemplo.)',
+
+    'Variadic reporters':
+        'Reporteros de aridad variable',
+    'Versions of +, x, AND, and OR that take more than two inputs.':
+        'Versiones de +, x, AND, y OR que toman m\u00E1s de dos argumentos.',
+
+    'Web services access (https)':
+        'Acceso a servicios web (https)',
+    'An extended version of the HTTP:// block that allows POST, PUT, and DELETE as well as GET requests, allows using the secure HTTPS protocol, and gives control over headers, etc.':
+        'Una versi\u00F3n extendida del bloque HTTP:// que permite hacer peticiones POST, PUT y DELETE adem\u00E1s de GET, utilizar el protocolo HTTPS, controlar cabeceras, etc...',
+
+    'Words, sentences':
+        'Palabras, frases',
+    'One of the big ideas in Logo that they left out of Scratch is thinking of text as structured into words and sentences, rather than just a string of characters.  This library (along with the JOIN WORDS block in the Tools library) brings back that idea.':
+        'Una de las mejores ideas de Logo no inclu\u00EDda en Scratch es la de considerar un texto como estructurado en palabras y frases, en lugar de simplemente una cadena de caracteres. Esta biblioteca (junto al bloque UNIR de la biblioteca Utilidades) recupera esa idea.',
+
+    'Multi-branched conditional (switch)':
+        'Condicionales multirama (switch)',
+    'Like "switch" in C-like languages or "cond" in Lisp.  Thanks to Nathan Dinsmore for inventing the idea of a separate block for each branch!':
+        'Como el "switch" de C o el "cond" de Lisp. \u00A1Gracias a Nathan Dinsmore por inventar la idea de un bloque separado para cada rama!',
+
+    'LEAP Motion controller':
+        'Control gestual (LEAP)',
+    'Report hand positions from LEAP Motion controller (leapmotion.com).':
+        'Reporta las posiciones de las manos desde el controlador de LEAP Motion (leapmotion.com).',
+
+    'Set RGB or HSV pen color':
+        'Colores RGB o HSV',
+    'Set or report pen color as RGB (red, blue, green) or HSV (hue, saturation, value).':
+        'Fija o devuelve el color del l\u00E1piz como RGB (rojo, azul, verde) o HSV (luminosidad, saturaci\u00F3n, valor).',
+
+    'Catch errors in a script':
+        'Captura de errores en programas',
+    'Run a script; if an error happens, instead of stopping the script with a red halo, run another script to handle the error. Also includes a block to cause an error with a message given as input. Also includes a block to create a script variable and give it a value.':
+        'Ejecuta un programa. Si ocurre alg\u00FAn error, en lugar de detener la ejecuci\u00F3n el programa con un mensaje en rojo puedes ejecutar otro programa para tratar el error. Tambi\u00E9n incluye un bloque para lanzar un error con un mensaje. Tambi\u00E9n incluye un bloque para crear una variable de programa y darle un valor.',
+
+    'Allow multi-line text input to a block':
+        'Texto multilinea',
+    'In general, text inputs allow only a single line.  The MULTILINE block accepts multi-line text input and can be used in text input slots of other blocks.':
+        'En general, las entradas de texto solo aceptan una \u00FAnica l\u00EDnea. El bloque MULTILINEA acepta texto en varias l\u00EDneas y puede ser usado como texto de entrada en otros bloques',
+
+    'Provide getters and setters for all GUI-controlled global settings':
+        'Manejo de opciones globales',
+
+    'Infinite precision integers, exact rationals, complex':
+        'Precisi\u00F3n arbitraria, racionales exactos, n\u00FAmeros complejos',
+    'The full Scheme numeric tower.  "USE BIGNUMS <True>" to enable.':
+        'La torre num\u00E9rica completa de Scheme. "UTILIZAR BIGNUMS <Verdad>" para activarla.',
+
+    'Provide 100 selected colors':
+        'Paleta de 100 colores preseleccionados',
+    'to use instead of hue for better selection':
+        'para usar en lugar de la luminosidad para una mejor selecci\u00F3n',
+
+    'Animation':
+        'Animaci\u00F3n',
+    'glide, grow and rotate using easing functions.':
+        'deslizamientos, zooms y rotaciones utilizando funciones curva.',
+
+    'Pixels':
+        'P\u00EDxeles',
+    'manipulate costumes pixel-wise.':
+        'manipula disfraces a nivel de pixel.',
+
+    'Audio Comp':
+        'Audio',
+    'analyze, manipulate and generate sound samples.':
+        'analiza, manipula y genera muestras de sonido',
+
+    // library dialog
+    'Import library':
+        'Importar biblioteca',
+    'Import':
+        'Importar',
+    'Imported':
+        'Se ha importado',
+    'Loading':
+        'Cargando',
 };

--- a/lang-es.js
+++ b/lang-es.js
@@ -615,18 +615,20 @@ SnapTranslator.dict.es = {
     // snap menu
     'About...':
         'Acerca de...',
+    'Reference manual':
+        'Manual de referencia',
     'Snap! website':
-        'Sitio Web de Snap!',
+        'Sitio web de Snap!',
     'Download source':
-        'Bajar recurso',
+        'Descargar c\u00F3digo fuente',
     'Switch back to user mode':
-        'Regresar a modo de usuario',
+        'Regresar a modo usuario',
     'disable deep-Morphic\ncontext menus\nand show user-friendly ones':
-        'inhabilitar men\u0075s contextuales de Morphic\ny mostrar unos f\u0061ciles de utilizar',
+        'inhabilitar men\u0075s contextuales de Morphic\ny mostrar unos f\u00E1ciles de utilizar',
     'Switch to dev mode':
-        'Cambiar a modo de elaborador',
+        'Cambiar a modo desarrollador',
     'enable Morphic\ncontext menus\nand inspectors,\nnot user-friendly!':
-        'habilitar men\u0075s contextuales\n e inspectores de Morphic,\n\u00A1no son f\u0061ciles de utilizar! ',
+        'habilitar men\u0075s contextuales\n e inspectores de Morphic,\n\u00A1no son f\u00E1ciles de utilizar!',
 
     // project menu
     'Project notes...':

--- a/lang-es.js
+++ b/lang-es.js
@@ -192,7 +192,7 @@ SnapTranslator.dict.es = {
     'untitled':
         'Sin t\u00EDtulo',
     'development mode':
-        'modo de desarrollo',
+        'modo desarrollador',
 
     // categories:
     'Motion':
@@ -285,10 +285,13 @@ SnapTranslator.dict.es = {
         without breaking its functionality.
     */
 
+    // shared messages:
+    'development mode \ndebugging primitives:':
+        'primitivas de depuraci\u00F3n\ndel modo desarrollador:',
+
     // motion:
     'Stage selected:\nno motion primitives':
-        'Escenario seleccionado:\nno hay primitivos de movimiento\n'
-            + 'disponibles',
+        'Escenario seleccionado:\nno hay primitivas de movimiento\ndisponibles',
 
     'move %n steps':
         'mover %n pasos',
@@ -323,6 +326,16 @@ SnapTranslator.dict.es = {
     'direction':
         'direcci\u00F3n',
 
+    // %dir values for (point in direction %dir):
+    '(90) right':
+        '(90) derecha',
+    '(-90) left':
+        '(-90) izquierda',
+    '(0) up':
+        '(0) arriba',
+    '(180) down':
+        '(180) abajo',
+
     // looks:
     'switch to costume %cst':
         'cambiar al disfraz %cst',
@@ -330,10 +343,6 @@ SnapTranslator.dict.es = {
         'siguiente disfraz',
     'costume #':
         '# de disfraz',
-    '%att of %spr':
-        '%att de %spr',
-    'my %get':
-        'mi(s) %get',
     'say %s for %n secs':
         'decir %s por %n segs',
     'say %s':
@@ -342,10 +351,6 @@ SnapTranslator.dict.es = {
         'pensar %s por %n segs',
     'think %s':
         'pensar %s',
-    'Hello!':
-        '\u00A1Hola!',
-    'Hmm...':
-        'mmm...',
     'change %eff effect by %n':
         'cambiar efecto %eff por %n',
     'set %eff effect to %n':
@@ -367,12 +372,53 @@ SnapTranslator.dict.es = {
     'go back %n layers':
         'enviar hacia atr\u00E1s %n capas',
 
-    'development mode \ndebugging primitives:':
-        'modo de desarrollo \nprimitivos de depuraci\u00F3n',
+    // looks' development mode primitives:
     'console log %mult%s':
-        'log de consola: %mult%s',
+        'registrar en consola %mult%s',
     'alert %mult%s':
-        'alerta: %mult%s',
+        'alerta %mult%s',
+    'save %imgsource as costume named %s':
+        'guardar %imgsource en disfraz %s',
+
+    // default values for (say %s):
+    'Hello!':
+        '\u00A1Hola!',
+
+    // default values for (think %s):
+    'Hmm...':
+        'Mmm...',
+
+    // %eff values for (change %eff effect by %n):
+    'color':
+        'color',
+    'fisheye':
+        'ojo de pez',
+    'whirl':
+        'remolino',
+    'pixelate':
+        'pixelado',
+    'mosaic':
+        'mosaico',
+    'duplicate':
+        'duplicar',
+    'negative':
+        'negativo',
+    'comic':
+        'historieta',
+    'confetti':
+        'confeti',
+    'saturation':
+        'saturaci\u00F3n',
+    'brightness':
+        'brillo',
+    'ghost':
+        'fantasma',
+
+    // %imgsource values for (save %imgsource as costume named %s):
+    'pen trails':
+        'rastro del l\u00E1piz',
+    'stage image':
+        'imagen del escenario',
 
     // sound:
     'play sound %snd':
@@ -393,6 +439,22 @@ SnapTranslator.dict.es = {
         'fijar tempo a %n',
     'tempo':
         'tempo',
+
+    // %note values for (play note %note for %n beats):
+    // Notes can be translated indeed but do it would break the piano layout
+    // example:
+    // 'Eb (63)':
+    //    '(63) Mi♭',
+
+    // %inst values for (set instrument to %inst):
+    '(1) sine':
+        '(1) \u223F\u223F onda sinusoidal',
+    '(2) square':
+        '(2) \u238D\u238D onda cuadrada',
+    '(3) sawtooth':
+        '(3) \u2A58\u2A58 onda dentada',
+    '(4) triangle':
+        '(4) \u22C0\u22C0 onda triangular',
 
     // pen:
     'clear':
@@ -419,28 +481,28 @@ SnapTranslator.dict.es = {
         'sellar',
     'fill':
         'llenar',
+    'pen trails':
+        'rastro del l\u00E1piz',
 
     // control:
     'when %greenflag clicked':
-        'Al presionar %greenflag',
+        'cuando se pulse %greenflag',
     'when %keyHat key pressed':
-        'Al presionar tecla %keyHat',
-    'when I am clicked':
-        'Cuando soy cliqueado',
+        'cuando se pulse la tecla %keyHat',
+    'when I am %interaction':
+        'cuando me %interaction',
     'when %b':
         'cuando %b',
     'when I receive %msgHat':
-        'Al recibir %msgHat',
+        'cuando me llegue %msgHat',
     'broadcast %msg':
         'enviar mensaje %msg',
     'broadcast %msg and wait':
         'enviar mensaje %msg y esperar',
-    'Message name':
-        'Nombre de mensaje',
     'message':
         'mensaje',
-    'any message':
-        'cualquier mensaje',
+    'warp %c':
+        'ejecutar en modo turbo %c',
     'wait %n secs':
         'esperar %n segs',
     'wait until %b':
@@ -457,24 +519,163 @@ SnapTranslator.dict.es = {
         'si %b %c si no %c',
     'report %s':
         'reportar %s',
-    'stop block':
-        'detener bloque',
-    'stop script':
-        'detener programa',
-    'stop all %stop':
-        'detener todo %stop',
+    'stop %stopChoices':
+        'detener %stopChoices',
     'run %cmdRing %inputs':
-        'correr %cmdRing %inputs',
+        'ejecutar %cmdRing %inputs',
     'launch %cmdRing %inputs':
         'iniciar %cmdRing %inputs',
     'call %repRing %inputs':
         'llamar %repRing %inputs',
+    'tell %spr to %cmdRing %inputs':
+        'decir a %spr que %cmdRing %inputs',
+    'ask %spr for %repRing %inputs':
+        'preguntar a %spr por %repRing %inputs',
     'run %cmdRing w/continuation':
-        'correr %cmdRing con continuaci\u00F3n',
+        'ejecutar %cmdRing con continuaci\u00F3n',
     'call %cmdRing w/continuation':
         'llamar %cmdRing con continuaci\u00F3n',
-    'warp %c':
-        'ejecutar en modo turbo %c',
+    'when I start as a clone':
+        'cuando comience como clon',
+    'create a clone of %cln':
+        'crear clon de %cln',
+    'a new clone of %cln':
+        'un nuevo clon de %cln',
+    'delete this clone':
+        'eliminar este clon',
+    'pause all %pause':
+        'pausar todos %pause',
+
+    // %keyHat values for (when %keyHat key pressed):
+    'space':
+        'espacio',
+    'up arrow':
+        '↑ (flecha arriba)',
+    'down arrow':
+        '↓ (flecha abajo)',
+    'right arrow':
+        '→ (flecha derecha)',
+    'left arrow':
+        '← (flecha izquierda)',
+    'any key':
+        'cualquier tecla',
+    'a':
+        'a',
+    'b':
+        'b',
+    'c':
+        'c',
+    'd':
+        'd',
+    'e':
+        'e',
+    'f':
+        'f',
+    'g':
+        'g',
+    'h':
+        'h',
+    'i':
+        'i',
+    'j':
+        'j',
+    'k':
+        'k',
+    'l':
+        'l',
+    'm':
+        'm',
+    'n':
+        'n',
+    'o':
+        'o',
+    'p':
+        'p',
+    'q':
+        'q',
+    'r':
+        'r',
+    's':
+        's',
+    't':
+        't',
+    'u':
+        'u',
+    'v':
+        'v',
+    'w':
+        'w',
+    'x':
+        'x',
+    'y':
+        'y',
+    'z':
+        'z',
+    '0':
+        '0',
+    '1':
+        '1',
+    '2':
+        '2',
+    '3':
+        '3',
+    '4':
+        '4',
+    '5':
+        '5',
+    '6':
+        '6',
+    '7':
+        '7',
+    '8':
+        '8',
+    '9':
+        '9',
+
+    // %interaction values for (when I am %interaction):
+    // In spanish read as "Cuando me %interaction"
+    'clicked':
+        'hagan clic',
+    'pressed':
+        'pulsen',
+    'dropped':
+        'arrastren y me suelten',
+    'mouse-entered':
+        'toquen con el rat\u00F3n',
+    'mouse-departed':
+        'dejen de tocar con el rat\u00F3n',
+    'scrolled-up':
+        'giren la rueda del rat\u00F3n hacia abajo',
+    'scrolled-down':
+        'giren la rueda del rat\u00F3n hacia arriba',
+
+    // "any message" for (when I receive %msgHat):
+    'any message':
+        'cualquier mensaje',
+
+    // "new..." for (broadcast %msg):
+    'new...':
+        'nuevo mensaje...',
+
+    // %stopChoices values for (stop %stopChoices):
+    'all':
+        'todos',
+    'this script':
+        'este programa',
+    'this block':
+        'este bloque',
+    'all but this script':
+        'todos los programas excepto este',
+    'other scripts in sprite':
+        'el resto de programas del objeto',
+
+    // "myself" for (create a clone of %cln)
+    'myself':
+        'm\u00ED mismo',
+
+    // New message name dialog:
+    'Message name':
+        'Nombre de mensaje',
 
     // sensing:
     'touching %col ?':
@@ -485,33 +686,120 @@ SnapTranslator.dict.es = {
         '\u00BFcolor %clr tocando %clr ?',
     'ask %s and wait':
         'preguntar %s y esperar',
-    'what\'s your name?':
-        '\u00BFC\u00F3mo es tu nombre?',
     'answer':
         'respuesta',
     'mouse x':
-        'x del mouse',
+        'rat\u00F3n x',
     'mouse y':
-        'y del mouse',
+        'rat\u00F3n y',
     'mouse down?':
-        '\u00BFrat\u00F3n abajo?',
+        '\u00BFrat\u00F3n pulsado?',
     'key %key pressed?':
-        '\u00BFtecla %key presionada?',
-    'distance to %dst':
-        'distancia a %dst',
+        '\u00BFtecla %key pulsada?',
+    '%rel to %dst':
+        '%rel a %dst',
     'reset timer':
         'reiniciar cron\u00F3metro',
     'timer':
         'cron\u00F3metro',
-    'http:// %s':
-        'http:// %s',
+    '%att of %spr':
+        '%att de %spr',
+    'my %get':
+        'mi(s) %get',
+    'url %s':
+        'url %s',
+    'turbo mode?':
+        '\u00BFmodo turbo?',
+    'set turbo mode to %b':
+         'fijar modo turbo a %b',
+    'current %dates':
+         '%dates actual',
 
+    // sensing's development mode primitives:
+    'processes':
+        'procesos',
     'filtered for %clr':
-        'filtrado para %clr',
+        'filtrado por %clr',
     'stack size':
         'tama\u00F1o de pila',
     'frames':
-        'marcos',
+        'cuadros',
+
+    // %col values for (touching %col ?):
+    'mouse-pointer':
+        'puntero del rat\u00F3n',
+    'edge':
+        'borde del escenario',
+    'pen trails':
+        'rastro del l\u00E1piz',
+
+    // default value for (ask %s and wait):
+    'what\'s your name?':
+        '\u00BFCu\u00E1l es tu nombre?',
+
+    // %rel values for (%rel to %dst):
+    'distance':
+        'distancia',
+    'direction':
+        'direcci\u00F3n',
+
+    // %get values for (my %get):
+    'neighbors':
+        'vecinos',
+    'self':
+        'mismo',
+    'other sprites':
+        'otros objetos',
+    'clones':
+        'clones',
+    'other clones':
+        'otros clones',
+    'parts':
+        'partes',
+    'anchor':
+        'anclaje',
+    'stage':
+        'escenario',
+    'children':
+        'hijos',
+    'parent':
+        'padre',
+    'temporary?':
+        '\u00BFsoy temporal?',
+    'name':
+        'nombre',
+    'costumes':
+        'disfraces',
+    'sounds':
+        'sonidos',
+    'dangling?':
+        '\u00BFcuelgo de otro objeto?',
+    'rotation x':
+        'rotaci\u00F3n x',
+    'rotation y':
+        'rotaci\u00F3n y',
+    'center x':
+        'centro x',
+    'center y':
+        'centro y',
+
+    // %dates values for (current %dates):
+    'year':
+        'a\u00F1o',
+    'month':
+        'mes',
+    'date':
+        'd\u00EDa',
+    'day of week':
+        'd\u00EDa de la semana',
+    'hour':
+        'hora',
+    'minute':
+        'minuto',
+    'second':
+        'segundo',
+    'time in milliseconds':
+        'tiempo en milisegundos',
 
     // operators:
     '%n mod %n':
@@ -534,10 +822,6 @@ SnapTranslator.dict.es = {
         'falso',
     'join %words':
         'unir %words',
-    'hello':
-        'hola',
-    'world':
-        'mundo',
     'split %s by %delim':
         'separar %s por %delim',
     'letter %n of %s':
@@ -545,18 +829,111 @@ SnapTranslator.dict.es = {
     'length of %s':
         'longitud de %s',
     'unicode of %s':
-        'UniC\u00F3digo de  %s',
+        'unic\u00F3digo de %s',
     'unicode %n as letter':
-        'UniC\u00F3digo %n como letra',
+        'unic\u00F3digo %n como letra',
     'is %s a %typ ?':
         '\u00BFes %s un %typ ?',
     'is %s identical to %s ?':
         '\u00BFes %s id\u00E9ntico a %s ?',
     'JavaScript function ( %mult%s ) { %code }':
-        'Función JavaScript  ( %mult%s ) { %code }',
+        'función JavaScript ( %mult%s ) { %code }',
 
+    // operators' developer mode primitives:
     'type of %s':
         'tipo de %s',
+    '%txtfun of %s':
+        '%txtfun de %s',
+    'compile %repRing':
+        'compilar %repRing',
+
+    // %fun values for (%fun of %n):
+    'abs':
+        'valor absoluto',
+    'ceiling':
+        'redondeo por arriba',
+    'floor':
+        'redondeo por abajo',
+    'sqrt':
+        'ra\u00EDz cuadrada',
+    'sin':
+        'seno',
+    'cos':
+        'coseno',
+    'tan':
+        'tangente',
+    'asin':
+        'arcoseno',
+    'acos':
+        'arcocoseno',
+    'atan':
+        'arcotangente',
+    'ln':
+        'log neperiano',
+    'log':
+        'log₁₀',
+    'e^':
+        'e^',
+    '10^':
+        '10^',
+
+    // default values for (join %words):
+    'hello':
+        'hola',
+    'world':
+        'mundo',
+
+    // %delim values (split by %delim)
+   'letter':
+       'letra',
+   'whitespace':
+       'espacio',
+   'line':
+       'l\u00EDnea',
+   'tab':
+       'tabulador',
+   'cr':
+       'retorno de carro',
+   'csv':
+       'coma',
+
+    // %typ values for (is %s a %typ ?)
+    'number':
+        'n\u00FAmero',
+    'text':
+        'texto',
+    'Boolean':
+        'booleano',
+    'list':
+        'lista',
+    'sprite':
+        'objeto',
+    'costume':
+        'disfraz',
+    'sound':
+        'sonido',
+    'command':
+        'comando',
+    'reporter':
+        'reportero',
+    'predicate':
+        'predicado',
+
+    // %txtfun values for (%txtfun of %s):
+    'encode URI':
+        'codificar URI',
+    'decode URI':
+        'decodificar URI',
+    'encode URI component':
+        'codificar componente URI',
+    'decode URI component':
+        'decodificar componente URI',
+    'XML escape':
+        'escapar XML',
+    'XML unescape':
+        'desescapar XML',
+    'hex sha512 hash':
+        'hash sha512 (hexadecimal)',
 
     // variables:
     'Make a variable':
@@ -592,8 +969,6 @@ SnapTranslator.dict.es = {
         'longitud de %l',
     '%l contains %s':
         '%l contiene %s',
-    'thing':
-        'cosa',
     'add %s to %l':
         'agregar %s a %l',
     'delete %ida of %l':
@@ -602,10 +977,24 @@ SnapTranslator.dict.es = {
         'insertar %s en %idx de %l',
     'replace item %idx of %l with %s':
         'reemplazar elemento %idx de %l con %s',
-    'copy of %l':
-        'copiar de %l',
-    'get text from %l seperated by %s':
-        'tomar texto de %l separado por %s',
+
+    // lists' development mode blocks:
+    'map %repRing over %l':
+        'mapear %repRing sobre %l',
+    'for %upvar in %l %cl':
+        'para %upvar en %l %cl',
+    'show table %l':
+        'mostrar tabla %l',
+
+    // %idx values for (item %idx of %l):
+    'last':
+        '\u00FAltimo',
+    'any':
+        'aleatorio',
+
+    // default value for (%l contains %s):
+    'thing':
+        'cosa',
 
     // other
     'Make a block':
@@ -1025,9 +1414,9 @@ SnapTranslator.dict.es = {
     'Live coding support':
         'Soporte para programaci\u00F3n en vivo',
     'EXPERIMENTAL! uncheck to disable live\ncustom control structures':
-        '¡EXPERIMENTAL! desmarcar para inhabilitar las\nestructuras de control personalizadas en vivo',
+        '\u00A1EXPERIMENTAL! desmarcar para inhabilitar las\nestructuras de control personalizadas en vivo',
     'EXPERIMENTAL! check to enable\n live custom control structures':
-        '¡EXPERIMENTAL! marcar para habilitar las\nestructuras de control personalizadas en vivo',
+        '\u00A1EXPERIMENTAL! marcar para habilitar las\nestructuras de control personalizadas en vivo',
 
     'Thread safe scripts':
         'Programas seguros para uso paralelo',
@@ -1077,7 +1466,7 @@ SnapTranslator.dict.es = {
 
     // stage size dialog
     'Stage size':
-        'Tamaño del escenario',
+        'Tama\u00F1o del escenario',
     'Stage width':
         'Anchura del escenario',
     'Stage height':
@@ -1157,30 +1546,6 @@ SnapTranslator.dict.es = {
     'rename costume':
         'renombrar disfraz',
         
-   // graphical effects
-    'color':
-        'Color',
-    'fisheye':
-        'Ojo de pez',
-    'whirl':
-        'Remolino',
-    'pixelate':
-        'Pixelado',
-    'mosaic':
-        'Mosaico',
-    'saturation':
-        'Saturación',
-    'brightness':
-        'Brillo',
-    'ghost':
-        'Fantasma',
-    'negative':
-        'Negativo',
-    'comic':
-        'Historieta',
-    'confetti':
-        'Confite',
-
     // sounds
     'Play sound':
         'Tocar sonido',
@@ -1376,301 +1741,9 @@ SnapTranslator.dict.es = {
     'add comment here...':
         'agregar comentario aqu\u00ED',
 
-    // drow downs
-    // directions
-    '(90) right':
-        '(90) derecha',
-    '(-90) left':
-        '(-90) izquierda',
-    '(0) up':
-        '(0) arriba',
-    '(180) down':
-        '(180) abajo',
-
-    // collision detection
-    'mouse-pointer':
-        'puntero del mouse',
-    'edge':
-        'borde',
-    'pen trails':
-        'rastro del l\u00E1piz',
-
     // costumes
     'Turtle':
         'Tortuga',
-
-    // graphical effects
-    'ghost':
-        'fantasma',
-
-    // keys
-    'space':
-        'espacio',
-    'up arrow':
-        'flecha de arriba',
-    'down arrow':
-        'flecha de abajo',
-    'right arrow':
-        'flecha derecha',
-    'left arrow':
-        'flecha izquierda',
-    'any key':
-        'cualquier tecla',
-    'a':
-        'a',
-    'b':
-        'b',
-    'c':
-        'c',
-    'd':
-        'd',
-    'e':
-        'e',
-    'f':
-        'f',
-    'g':
-        'g',
-    'h':
-        'h',
-    'i':
-        'i',
-    'j':
-        'j',
-    'k':
-        'k',
-    'l':
-        'l',
-    'm':
-        'm',
-    'n':
-        'n',
-    'o':
-        'o',
-    'p':
-        'p',
-    'q':
-        'q',
-    'r':
-        'r',
-    's':
-        's',
-    't':
-        't',
-    'u':
-        'u',
-    'v':
-        'v',
-    'w':
-        'w',
-    'x':
-        'x',
-    'y':
-        'y',
-    'z':
-        'z',
-    '0':
-        '0',
-    '1':
-        '1',
-    '2':
-        '2',
-    '3':
-        '3',
-    '4':
-        '4',
-    '5':
-        '5',
-    '6':
-        '6',
-    '7':
-        '7',
-    '8':
-        '8',
-    '9':
-        '9',
-
-    // messages
-    'new...':
-        'crear nuevo mensaje...',
-
-    // math functions
-    'abs':
-        'abs',
-    'ceiling':
-        'redondear hacia arriba',
-    'floor':
-        'redondear hacia abajo',
-    'sqrt':
-        'ra\u00EDz cuadrada',
-    'sin':
-        'sen',
-    'cos':
-        'cos',
-    'tan':
-        'tan',
-    'asin':
-        'asen',
-    'acos':
-        'acos',
-    'atan':
-        'atan',
-    'ln':
-        'ln',
-    'e^':
-        'e^',
-
-     // delimiters
-    'letter':
-        'Letra',
-    'whitespace':
-        'Espacio',
-    'line':
-        'Línea',
-    'tab':
-        'Tabulador',
-    'cr':
-        'Retorno de línea',
-    'csv':
-        'Coma',
-
-    // data types
-    'number':
-        'n\u00FAmero',
-    'text':
-        'texto',
-    'Boolean':
-        'Booleano',
-    'list':
-        'lista',
-    'command':
-        'comando',
-    'reporter':
-        'reportero',
-    'predicate':
-        'predicado',
-
-    // list indices
-    'last':
-        '\u00FAltimo',
-    'any':
-        'cualquier',
-
-    // attributes
-    'neighbors':
-        'vecinos',
-    'self':
-        'yo mismo',
-    'other sprites':
-        'otros Objetos',
-    'parts':
-        'partes',
-    'anchor':
-        'anclaje',
-    'parent':
-        'padre',
-    'children':
-        'hijo',
-    'clones':
-        'clones',
-    'other clones':
-        'otros clones',
-    'dangling?':
-        'colgado?',
-    'rotation x':
-        'rotación x',
-    'rotation y':
-        'rotación y',
-    'center x':
-        'centro x',
-    'center y':
-        'centro y',
-    'name':
-        'nombre',
-    'stage':
-        'escenario',
-    'costumes':
-        'disfraces',
-    'sounds':
-        'sonidos',
-    'scripts':
-        'scripts',
-
-    // MISSING UPSTREAM:
-
-	'when I am %interaction':
-		'Cuando soy %interaction',
-	'clicked':
-        'cliqueado',
-    'pressed':
-        'presionado',
-    'dropped':
-        'soltado',
-    'mouse-entered':
-        'pasado el mouse por encima sin cliquear',
-    'mouse-departed':
-        'pasado el mouse por encima sin cliquear y luego alejar',
-    'stop %stopChoices':
-        'detener %stopChoices',
-    'all':
-        'todos',
-    'this script':
-        'este script',
-    'this block':
-        'este bloque',
-    'stop %stopOthersChoices':
-        'detener %stopOthersChoices',
-    'all but this script':
-        'todos excepto este script',
-    'other scripts in sprite':
-        'otros scripts del objeto',
-    'pause all %pause':
-        'pausar todos %pause',
-    'when I start as a clone':
-        'Al comenzar como clon',
-    'create a clone of %cln':
-        'crear clon de %cln',
-    'myself':
-        'mío',
-     'a new clone of %cln':
-        'un nuevo clon de %cln',
-    'delete this clone':
-        'eliminar este clon',
-
-    // under "broadcast %msg and wait"
-    'message':
-        'mensaje',
-    'turbo mode?':
-        'modo turbo?',
-    'set turbo mode to %b':
-         'fijar modo turbo a %b',
-    'current %dates':
-         '%dates actual',
-    'year':
-        'año',
-    'month':
-        'mes',
-    'date':
-        'fecha',
-    'day of week':
-        'día de la semana',
-    'hour':
-        'hora',
-    'minute':
-        'minuto',
-    'second':
-        'segundo',
-    'time in milliseconds':
-        'tiempo en milisegundos',
-
-    // under "graphical effects"
-    'brightness':
-        'brillo',
-    'negative':
-        'negativo',
-    'comic':
-        'historieta',
-    'confetti':
-        'confite',
 
     //libraries
     'Tools':

--- a/lang-es.js
+++ b/lang-es.js
@@ -418,6 +418,8 @@ SnapTranslator.dict.es = {
         'siguiente disfraz',
     'costume #':
         '# de disfraz',
+    'costume name':
+        'nombre del disfraz',
     'say %s for %n secs':
         'decir %s por %n segs',
     'say %s':
@@ -448,6 +450,8 @@ SnapTranslator.dict.es = {
         'enviar hacia atr\u00E1s %n capas',
 
     // looks' development mode primitives:
+    'wardrobe': // objects.js:401
+        'guardarropa',
     'console log %mult%s':
         'registrar en consola %mult%s',
     'alert %mult%s':
@@ -458,6 +462,8 @@ SnapTranslator.dict.es = {
     // default values for (say %s):
     'Hello!':
         '\u00A1Hola!',
+    'Hello, World!':
+        '\u00A1Hola, Mundo!',
 
     // default values for (think %s):
     'Hmm...':
@@ -514,6 +520,10 @@ SnapTranslator.dict.es = {
         'fijar tempo a %n',
     'tempo':
         'tempo',
+
+    // sound development mode blocks
+    'jukebox': // objects.js:474
+        'gramola',
 
     // %note values for (play note %note for %n beats):
     // Notes can be translated indeed but do it would break the piano layout
@@ -912,7 +922,7 @@ SnapTranslator.dict.es = {
     'is %s identical to %s ?':
         '\u00BFes %s id\u00E9ntico a %s ?',
     'JavaScript function ( %mult%s ) { %code }':
-        'función JavaScript ( %mult%s ) { %code }',
+        'funci\u00F3n JavaScript ( %mult%s ) { %code }',
 
     // operators' developer mode primitives:
     'type of %s':
@@ -944,9 +954,9 @@ SnapTranslator.dict.es = {
     'atan':
         'arcotangente',
     'ln':
-        'log neperiano',
+        'ln',
     'log':
-        'log₁₀',
+        'log',
     'e^':
         'e^',
     '10^':
@@ -1027,6 +1037,21 @@ SnapTranslator.dict.es = {
     'check to prevent contents\nfrom being saved':
         'marcar para no guardar\nel contenido junto con el proyecto',
 
+    'rename...':
+        'renombrar...',
+    'rename only\nthis reporter':
+        'renombra s\u00F3lo\neste reportero',
+    'rename all...':
+        'renombrar todos...',
+    'rename all blocks that\naccess this variable':
+        'renombra todos los bloques\nque acceden a esta variable',
+    'inherited':
+        'herencia',
+    'uncheck to\ndisinherit':
+        'desmarcar para no heredar',
+    'check to inherit\nfrom':
+        'marcar para heredar de',
+
     'set %var to %s':
         'fijar %var a %s',
     'change %var by %n':
@@ -1039,6 +1064,10 @@ SnapTranslator.dict.es = {
         'variables de programa %scriptVars',
     'inherit %shd':
         'heredar %shd',
+    'a variable of name \'':
+        'no existe ninguna variable llamada\n\'',
+    '\'\ndoes not exist in this context':
+        '\'\nen este contexto',
 
     // lists:
     'list %exp':
@@ -1108,6 +1137,12 @@ SnapTranslator.dict.es = {
     'false':
         'falso',
 
+    // %codeKind values for (map %cmdRing to %codeKind %code)
+    'code':
+        'c\u00F3digo',
+    'header':
+        'cabecera',
+
     // %mapValue values for (map %mapValue to code %code):
     'list':
         'lista',
@@ -1115,6 +1150,14 @@ SnapTranslator.dict.es = {
         'elemento',
     'delimiter':
         'delimitador',
+
+    // $codeListKind values for (map %codeListPart of %codeListKind to code %code)
+    'collection':
+        'colecci\u00F3n',
+    'variables':
+        'variables',
+    'parameters':
+        'par\u00E1metros',
 
     // menus
     // snap menu
@@ -1196,7 +1239,7 @@ SnapTranslator.dict.es = {
     'Import tools':
         'Importar utilidades',
     'load the official library of\npowerful blocks':
-        'carga la biblioteca oficial de\nbloques potentes',
+        'carga la biblioteca oficial de\nbloques avanzados',
 
     'Libraries...':
         'Bibliotecas...',
@@ -1243,7 +1286,7 @@ SnapTranslator.dict.es = {
     'url...':
         'Url...',
     'export project media only...':
-        'Exportar solamente medios del proyecto...',
+        'Exportar s\u00F3lo medios del proyecto...',
     'export project without media...':
         'Exportar proyecto sin medios...',
     'export project as cloud data...':
@@ -1272,6 +1315,8 @@ SnapTranslator.dict.es = {
         'a\u00F1o:',
     'E-mail address:':
         'Correo electr\u00F3nico:',
+    'E-mail address of parent or guardian:':
+        'Correo electr\u00F3nico del padre/madre o tutor legal',
     'Password:':
         'Contrase\u00F1a:',
     'Repeat Password:':
@@ -1310,6 +1355,19 @@ SnapTranslator.dict.es = {
     'or before':
         'o antes',
 
+    'please fill out\nthis field':
+        'por favor,\ncompleta este campo',
+    'User name must be four\ncharacters or longer':
+        'el nombre de usuario ha de tener\ncomo m\u00EDnimo 4 caracteres',
+    'please provide a valid\nemail address':
+        'por favor, proporciona\nuna direcci\u00F3n de correo v\u00E1lida',
+    'password must be six\ncharacters or longer':
+        'la contrase\u00F1a ha de tener\ncomo m\u00EDnimo 6 caracteres',
+    'passwords do\nnot match':
+        'las contrase\u00F1a no coindicen',
+    'please agree to\nthe TOS':
+        'por favor, acepta los\nt\u00E9rminos y condiciones de uso',
+
     // signin dialog
     'Sign in':
         'Iniciar sesi\u00F3n',
@@ -1333,6 +1391,8 @@ SnapTranslator.dict.es = {
         'Nueva contrase\u00F1a:',
     'Repeat new password:':
         'Repetir nueva contrase\u00F1a:',
+    'password has been changed.':
+        'Contrase\u00F1a cambiada.',
 
     // open shared project in cloud dialog
     'Author name\u2026':
@@ -1343,6 +1403,15 @@ SnapTranslator.dict.es = {
         'Descargando proyecto\ndesde la nube...',
     'Opening project...':
         'Abriendo proyecto...',
+
+    'Cloud Connection':
+        'Conexi\u00F3n con la nube',
+    'Successfully connected to:':     // would this be translated? (gui.js:5439)
+        'Conectado correctamente a:',
+    'disconnected.':
+        'Desconectado.',
+    'You are not logged in':
+        'No has iniciado sesi\u00F3n',
 
     // settings menu
     'Language...':
@@ -1648,7 +1717,7 @@ SnapTranslator.dict.es = {
     'make a copy\nand pick it up':
         'crea una copia y\npermite moverla a otra parte',
     'only duplicate this block':
-        'duplica solamente este bloque',
+        'duplica s\u00F3lo este bloque',
     'delete':
         'borrar',
 
@@ -1657,10 +1726,37 @@ SnapTranslator.dict.es = {
     'open a new window\nwith a picture of this script':
         'abre una nueva ventana\ncon una imagen de este programa',
 
+    'download script':
+        'descargar programa',
+    'download this script\nas an XML file':
+        'descarga este programa en XML',
+
+    'script pic with result...':
+        'imagen de programa con resultado...',
+    'open a new window\nwith a picture of both\nthis script and its result':
+        'abre una nueva ventana\ncon una imagen de este programa y su resultado',
+
     'ringify':
         'encapsular',
     'unringify':
         'desencapsular',
+
+    'header mapping...':
+        'mapeo a cabecera...',
+    'code mapping...':
+        'mapeo a c\u00F3digo...',
+
+    // Map to header/code dialog:
+    'Header mapping':
+        'Mapeo a cabecera',
+    'Enter code that corresponds to the block\'s definition. Use the formal parameter\nnames as shown and <body> to reference the definition body\'s generated text code.':
+        'Escribe el c\u00F3digo correspondiente a la definici\u00F3n del bloque.\nUsa los nombres de los par\u00E1metros formales aqu\u00ED mostrados\ny <body> para referenciar el c\u00F3digo generado del cuerpo de la definici\u00F3n.',
+    'Enter code that corresponds to the block\'s definition. Choose your own\nformal parameter names (ignoring the ones shown).':
+        'Escribe el c\u00F3digo correspondiente a la definici\u00F3n del bloque.\nPuedes usar tus propios par\u00E1metros formales (ignora los aqu\u00ED mostrados).',
+    'Code mapping':
+        'Mapeo a c\u00F3digo',
+    'Enter code that corresponds to the block\'s operation (usually a single\nfunction invocation). Use <#n> to reference actual arguments as shown.':
+        'Escribe el c\u00F3digo correspondiente a la implementaci\u00F3n del bloque\n(normalmente una \u00FAnica llamada a funci\u00F3n).\nUsa <#n> para referenciar los argumentos aqu\u00ED mostrados.',
 
     // custom blocks context menus:
     'delete block definition...':
@@ -1683,10 +1779,26 @@ SnapTranslator.dict.es = {
     // sprites:
     'edit':
         'editar',
+    'rotate':
+        'rotar',
+    'move':
+        'mover',
     'clone':
         'clonar',
     'parent...':
         'padre...',
+    'current parent':
+        'padre actual',
+    'none':
+        'ninguno',
+    'release':
+        'liberar',
+    'make temporary and\nhide in the sprite corral':
+        'lo hace temporal y oculta\nen el corral de objetos',
+    'detach from':
+        'desvincular de',
+    'detach all parts':
+        'desvincular todo',
     'export...':
         'exportar...',
 
@@ -1713,6 +1825,10 @@ SnapTranslator.dict.es = {
         'rehacer',
     'redo the last undone\nblock drop\nin this pane':
         'rehace el \u00FAltimo cambio\ndeshecho con bloques',
+    'clear undrop queue':
+        'vaciar historial de cambios',
+    'forget recorded block drops\non this pane':
+        'olvida el historial\nde cambios hechos con bloques',
     'clean up':
         'ordenar',
     'arrange scripts\nvertically':
@@ -1752,6 +1868,20 @@ SnapTranslator.dict.es = {
     'Stop sound':
         'detiene este sonido',
 
+    // lists context menu
+    'items':
+        'elementos',
+    'reset columns':
+        'reiniciar columnas',
+    'open in another dialog...':
+        'abrir en otro di\u00E1logo',
+    'table view...':
+        'ver como tabla...',
+    'list view...':
+        'ver como lista...',
+    'open in dialog...':
+        'abrir en di\u00E1logo...',
+
     // rename costume dialog:
     'rename background':
         'Renombrar disfraz',
@@ -1759,6 +1889,362 @@ SnapTranslator.dict.es = {
     // rename sound dialog:
     'rename sound':
         'Renombrar sonido',
+
+    // comments context menu
+    'comment pic...':
+        'imagen de comentario...',
+    'open a new window\nwith a picture of this comment':
+        'abre una nueva ventana\ncon una imagen de este comentario',
+
+    // morph context menu
+    'user features':
+        'men\u00FA de usuario',
+
+    'color...':
+        'color...',
+    '\ncolor:':
+        '\ncolor:',
+    'choose another color \nfor this morph':
+        'elige otro color\npara este morph',
+
+    'transparency...':
+        'transparencia...',
+    '\nalpha\nvalue:':
+        'valor alfa',
+    'set this morph\'s\nalpha value':
+        'establece el valor alfa\nde este morph',
+
+    'resize...':
+        'redimensionar...',
+    'show a handle\nwhich can be dragged\nto change this morph\'s extent':
+        'muestra una muesca que puede ser arrastrada\npara cambiar el tama\u00F1o de este morph',
+
+    'duplicate':
+        'duplicar',
+    'make a copy\nand pick it up':
+        'crea una copia y\npermite moverla a otro lugar',
+
+    'pick up':
+        'coger',
+    'detach and put \ninto the hand':
+        'permite moverlo a otro lugar',
+
+    'attach...':
+        'vincular',
+    'stick this morph\nto another one':
+        'pega este morph a otro',
+
+    'move...':
+        'mover...',
+    'show a handle\nwhich can be dragged\nto move this morph':
+        'muestra una muesca que puede ser\narrastrada para mover este morph',
+
+    'inspect...':
+        'inspeccionar',
+    'open a window\non all properties':
+        'abre una ventana\ncon todas las propiedades',
+    'open a window on\nall properties':
+        'abre una ventana\ncon todas las propiedades',
+
+    'pic...':
+        'imagen...',
+    'open a new window\nwith a picture of this morph':
+        'abre una nueva ventana\ncon una image de este morph',
+
+    'lock':
+        'bloquear',
+    'make this morph\nunmovable':
+        'impide que este morph\nse pueda mover',
+
+    'unlock':
+        'desbloquear',
+    'make this morph\nmovable':
+        'permite que este morph\nse pueda mover',
+
+    'hide':
+        'ocultar',
+
+    'delete':
+        'eliminar',
+
+    'World...':
+        'Mundo...',
+    'show the\nWorld\'s menu':
+        'muestra el men\u00FA del Mundo',
+
+    'set rotation':
+        'rotar',
+    'interactively turn this morph\nusing a dial widget':
+        'gira este morph\nutilizando un control de disco',
+    'edit rotation point only...':
+        'editar s\u00F3lo punto de rotaci\u00F3n...',
+    'pivot':
+        'pivote',
+    'edit the costume\'s\nrotation center':
+        'edita el centro\nde rotaci\u00F3n del disfraz',
+    'edit':
+        'editar',
+    'make permanent and\nshow in the sprite corral':
+        'lo hace permanente y\nlo muestra en el corral de objetos',
+
+    'move all inside...':
+        'mover todos dentro...',
+    'keep all submorphs\nwithin and visible':
+        'retiene dentro y hace visibles\ntodos los sub-morphs',
+
+    'stop':
+        'detener',
+    'terminate all running threads':
+        'termina todos los hilos en ejecuci\u00F3n',
+
+    'auto line wrap off...':
+        'desactivar ajuste de l\u00EDnea...',
+    'turn automatic\nline wrapping\noff':
+        'desactiva el ajuste\nde l\u00EDnea autom\u00E1tico',
+    'auto line wrap on...':
+        'activar ajuste de l\u00EDnea...',
+    'enable automatic\nline wrapping':
+        'activa el ajuste\nde l\u00EDnea autom\u00E1tico',
+
+    'delete block':
+        'eliminar bloque',
+    'spec...':
+        'definici\u00F3n...',
+
+    'font size...':
+        'tama\u00F1o de fuente...',
+    'set this String\'s\nfont point size':
+        'establece el tama\u00F1o de fuente\nde este texto',
+
+    'serif':
+        'serif',
+    'sans-serif':
+        'sans-serif',
+    'normal weight':
+        'grosor normal',
+    'bold':
+        'negrita',
+    'normal style':
+        'estilo normal',
+    'italic':
+        'cursiva',
+    'hide blanks':
+        'ocultar espacios',
+    'show blanks':
+        'mostrar espacios',
+    'show characters':
+        'mostrar caracteres',
+    'hide characters':
+        'ocultar caracteres',
+
+    'middle':
+        'mitad',
+    'tip':
+        'punta',
+
+    'screenshot':
+        'imagen',
+
+    'make a morph':
+        'crear un morph',
+
+    // WorldMorph context menu
+    'demo...':
+        'demo...',
+    'sample morphs':
+        'morphs de muestra',
+    'hide all...':
+        'ocultar todos...',
+    'show all...':
+        'mostrar todos...',
+    'screenshot...':
+        'captura de pantalla...',
+    'restore display':
+        'restaurar pantalla',
+    'redraw the\nscreen once':
+        'redibuja la pantalla',
+    "fill page...":
+        'llenar p\u00E1gina',
+    'let the World automatically\nadjust to browser resizing':
+        'hace que el Mundo se ajuste\nautom\u00E1ticamente cuando\nse redimensiona el navegador', // @todo
+    'sharp shadows...':
+        'sombras n\u00EDtidas...',
+    'sharp drop shadows\nuse for old browsers':
+        'sombras n\u00EDtidas\n(para navegadores antiguos)',
+    'blurred shadows...':
+        'sombras difuminadas...',
+    'blurry shades,\n use for new browsers':
+        'sombras difuminadas\n(para navegadores modernos)',
+    'color...':
+        'color...',
+    'choose the World\'s\nbackground color':
+        'selecciona el color\nde fondo del Mundo',
+    'touch screen settings':
+        'perfil de pantallas t\u00E1ctiles',
+    'bigger menu fonts\nand sliders':
+        'fuentes y deslizadores\nm\u00E1s grandes',
+    'standard settings':
+        'perfil de ordenador',
+    'smaller menu fonts\nand sliders':
+        'fuentes y deslizadores m\u00E1s peque\u00F1os',
+    'user mode...':
+        'modo usuario...',
+    'disable developers\'\ncontext menus':
+        'desactiva los men\u00FAs\ncontextuales de desarrollador',
+    'development mode...':
+        'modo desarrollador...',
+    'about morphic.js...':
+        'acerca de morphic.js',
+
+    // morph samples
+    'rectangle':
+        'rect\u00E1ngulo',
+    'box':
+        'caja',
+    'circle box':
+        'caja circular',
+    'slider':
+        'deslizador',
+    'dial':
+        'disco',
+    'frame':
+        'panel',
+    'scroll frame':
+        'panel con deslizadores',
+    'handle':
+        'muesca',
+    'string':
+        'string',
+    'text':
+        'texto',
+    'speech bubble':
+        'mensaje popup',
+    'gray scale palette':
+        'paleta de grises',
+    'color palette':
+        'paleta de color',
+    'color picker':
+        'medidor de color',
+    'sensor demo':
+        'demo: sensor',
+    'animation demo':
+        'demo: animaci\u00F3n',
+    'pen':
+        'tortuga',
+
+    // custom block text fragment symbols
+    'square':
+        'cuadrado',
+    'pointRight':
+        'apuntar a la derecha',
+    'stepForward':
+        'siguiente paso',
+    'gears':
+        'engranaje',
+    'file':
+        'fichero',
+    'fullScreen':
+        'pantalla completa',
+    'normalScreen':
+        'pantalla normal',
+    'smallStage':
+        'escenario peque\u00F1o',
+    'normalStage':
+        'escenario normal',
+    'turtle':
+        'tortuga',
+    'stage':
+        'escenario',
+    'turtleOutline':
+        'tortuga (contorno)',
+    'pause':
+        'pausa',
+    'flag':
+        'bander\u00EDn',
+    'octagon':
+        'oct\u00F3gono',
+    'cloud':
+        'nube',
+    'cloudOutline':
+        'nube (contorno)',
+    'cloudGradient':
+        'nube (degradado)',
+    'turnRight':
+        'giro a la derecha',
+    'turnLeft':
+        'giro a la izquierda',
+    'storage':
+        'almacenamiento',
+    'poster':
+        'p\u00F3ster',
+    'flash':
+        'rel\u00E1mpago',
+    'brush':
+        'pincel',
+    'rectangle':
+        'rect\u00E1ngulo',
+    'rectangleSolid':
+        'rect\u00E1ngulo (s\u00F3lido)',
+    'circle':
+        'c\u00EDrculo',
+    'circleSolid':
+        'c\u00EDrculo (s\u00F3lido)',
+    'line':
+        'l\u00EDnea',
+    'cross':
+        'cruz',
+    'crosshairs':
+        'punto de mira',
+    'paintbucket':
+        'bote de pintura',
+    'eraser':
+        'goma de borrar',
+    'pipette':
+        'cuentagotas',
+    'speechBubble':
+        'bocadillo',
+    'speechBubbleOutline':
+        'bocadillo (contorno)',
+    'turnBack':
+        'ir atr\u00E1s',
+    'turnForward':
+        'ir adelante',
+    'arrowUp':
+        'flecha arriba',
+    'arrowUpOutline':
+        'flecha arriba (contorno)',
+    'arrowLeft':
+        'flecha izquierda',
+    'arrowLeftOutline':
+        'flecha izquierda (contorno)',
+    'arrowDown':
+        'flecha abajo',
+    'arrowDownOutline':
+        'flecha abajo (contorno)',
+    'arrowRight':
+        'flecha derecha',
+    'arrowRightOutline':
+        'flecha derecha (contorno)',
+    'robot':
+        'robot',
+    'magnifyingGlass':
+        'lupa',
+    'magnifierOutline':
+        'lupa (contorno)',
+    'notes':
+        'notas musicales',
+    'camera':
+        'c\u00E1mara',
+    'location':
+        'ubicaci\u00F3n',
+    'footprints':
+        'huellas de pasos',
+    'keyboard':
+        'teclado',
+    'keyboardFilled':
+        'teclado (s\u00F3lido)',
+    'new line':
+        'nueva l\u00EDnea',
 
     // dialogs
     // buttons
@@ -1768,6 +2254,8 @@ SnapTranslator.dict.es = {
         'Aceptar',
     'Cancel':
         'Cancelar',
+    'Default':
+        'Predeterminado',
     'Yes':
         'S\u00ED',
     'No':
@@ -1788,12 +2276,18 @@ SnapTranslator.dict.es = {
         'Guardar proyecto como...',
     '(empty)':
         '(vac\u00EDo)',
+    '(no matches)':
+        '(ninguna coincidencia)',
     'Open':
         'Abrir',
     'Delete':
         'Eliminar',
+    'Share':
+        'Compartir',
     'Share Project':
         'Compartir',
+    'Unshare':
+        'No compartir',
     'Unshare Project':
         'Dejar de compartir',
     'Saved!':
@@ -1808,6 +2302,12 @@ SnapTranslator.dict.es = {
         'Navegador',
     'Examples':
         'Ejemplos',
+    'Updating\nproject list...':
+        'Actualizando\nlista de proyectos...',
+    'Saving project\nto the cloud...':
+        'Guardando proyecto\nen la nube...',
+    'saved.':
+        'Guardado.',
     'last changed':
         '\u00FAltima modificaci\u00F3n',
     'Are you sure you want to share':
@@ -1822,6 +2322,22 @@ SnapTranslator.dict.es = {
         'dejando de compartir...',
     'unshared.':
         'no compartido.',
+    'Are you sure you want to publish':
+        '\u00BFEst\u00E1s seguro de que\nquieres publicar',
+    'Are you sure you want to unpublish':
+        '\u00BFEst\u00E1s seguro de que\nquieres dejar de publicar',
+    'Publish Project':
+        'Publicar proyecto',
+    'Unpublish Project':
+        'Dejar de publicar',
+    'publishing\nproject...':
+        'Publicando\nproyecto...',
+    'unpublishing\nproject...':
+        'Cancelando publicaci\u00F3n...',
+    'published.':
+        'Publicado.',
+    'unpublished.':
+        'No publicado',
 
     // costume editor
     'Costume Editor':
@@ -1872,6 +2388,8 @@ SnapTranslator.dict.es = {
     // block editor
     'Block Editor':
         'Editor de bloques',
+    'Method Editor':
+        'Editor de m\u00E9todos',
     'Apply':
         'Aplicar',
     'block variables':
@@ -1990,7 +2508,7 @@ SnapTranslator.dict.es = {
 
     // coments
     'add comment here...':
-        'añadir comentario aqu\u00ED...',
+        'a\u00F1adir comentario aqu\u00ED...',
 
     // exported summary
     'Contents':
@@ -2024,7 +2542,7 @@ SnapTranslator.dict.es = {
     'Tools':
         'Utilidades',
     'Standard library of powerful blocks (for, map, etc.)':
-        'Biblioteca est\u00E1ndar de bloques potentes (for, map, etc...)',
+        'Biblioteca est\u00E1ndar de bloques avanzados (for, map, etc...)',
 
     'Iteration, composition':
         'Iteraci\u00F3n, composici\u00F3n',
@@ -2118,4 +2636,12 @@ SnapTranslator.dict.es = {
         'Se ha importado',
     'Loading':
         'Cargando',
+
+    // threads.js
+    'expecting':
+        'se esperaban las entradas',
+    'input(s), but getting':
+        'pero se ha encontrado',
+    '(temporary)':
+        '(temporal)',
 };

--- a/lang-es.js
+++ b/lang-es.js
@@ -1559,7 +1559,7 @@ SnapTranslator.dict.es = {
     'help':
         'ayuda',
 
-    // blocks:
+    // blocks context menus:
     'help...':
         'ayuda...',
     'relabel...':
@@ -1567,45 +1567,73 @@ SnapTranslator.dict.es = {
     'duplicate':
         'duplicar',
     'make a copy\nand pick it up':
-        'crear una copia y recogerla',
+        'crea una copia y\npermite moverla a otra parte',
     'only duplicate this block':
-        'duplicar s\u00F3lo este bloque',
+        'duplica solamente este bloque',
     'delete':
         'borrar',
-    'script pic...':
-        'foto de programa...',
-    'open a new window\nwith a picture of this script':
-        'abrir una nueva ventana\ncon una foto de este programa',
-    'ringify':
-        'zumbar',
-    'unringify':
-        'deszumbar',
 
-    // custom blocks:
+    'script pic...':
+        'imagen de programa...',
+    'open a new window\nwith a picture of this script':
+        'abre una nueva ventana\ncon una imagen de este programa',
+
+    'ringify':
+        'encapsular',
+    'unringify':
+        'desencapsular',
+
+    // custom blocks context menus:
     'delete block definition...':
-        'borrar definici\u00F3n de bloque',
+        'eliminar definici\u00F3n de bloque...',
     'edit...':
         'editar...',
 
     // sprites:
     'edit':
         'editar',
+    'clone':
+        'clonar',
+    'parent...':
+        'padre...',
     'export...':
         'exportar...',
 
     // stage:
     'show all':
         'mostrar todos',
+    'pic...':
+        'imagen...',
+    'open a new window\nwith a picture of the stage':
+        'abre una nueva ventana\ncon una imagen del escenario',
+    'pen trails':
+        'rastro del l\u00E1piz',
+    'turn all pen trails and stamps\ninto a new costume for the\ncurrently selected sprite':
+        'convierte todo rastro del l\u00E1piz\nen un nuevo disfraz para el objeto\nactualmente seleccionado',
+    'turn all pen trails and stamps\ninto a new background for the stage':
+        'convierte todo rastro del l\u00E1piz\nen un nuevo fondo para el escenario',
 
-    // scripting area
+    // scripting area:
+    'undrop':
+        'deshacer',
+    'undo the last\nblock drop\nin this pane':
+        'deshace el \u00FAltimo cambio\nhecho con bloques',
+    'redrop':
+        'rehacer',
+    'redo the last undone\nblock drop\nin this pane':
+        'rehace el \u00FAltimo cambio\ndeshecho con bloques',
     'clean up':
-        'limpiar',
+        'ordenar',
     'arrange scripts\nvertically':
-        'alinear programas\nverticalmente',
+        'alinea los programas\nverticalmente',
     'add comment':
-        'agregar comentario',
+        'a\u00F1adir comentario',
+    'scripts pic...':
+        'imagen de programas...',
+    'open a new window\nwith a picture of all scripts':
+        'abre una nueva ventana\ncon una imagen de todos los programas',
     'make a block...':
-        'crear un bloque...',
+        'crear bloque...',
 
     // costumes
     'rename':
@@ -1616,23 +1644,29 @@ SnapTranslator.dict.es = {
         'renombrar disfraz',
         
     // sounds
+    'Play':
+        'Reproducir',
     'Play sound':
-        'Tocar sonido',
-    'Stop sound':
-        'Detener sonido',
+        'reproduce este sonido',
     'Stop':
         'Detener',
-    'Play':
-        'Tocar',
+    'Stop sound':
+        'detiene este sonido',
+
+    // rename costume dialog:
+    'rename background':
+        'Renombrar disfraz',
+
+    // rename sound dialog:
     'rename sound':
-        'renombrar sonido',
+        'Renombrar sonido',
 
     // dialogs
     // buttons
     'OK':
-        'OK',
+        'Aceptar',
     'Ok':
-        'Ok',
+        'Aceptar',
     'Cancel':
         'Cancelar',
     'Yes':
@@ -1649,36 +1683,46 @@ SnapTranslator.dict.es = {
         'Sin T\u00EDtulo',
     'Open Project':
         'Abrir Proyecto',
+    'Save Project':
+        'Guardar proyecto',
+    'Save Project As...':
+        'Guardar proyecto como...',
     '(empty)':
-        '(vacio)',
+        '(vac\u00EDo)',
+    'Open':
+        'Abrir',
+    'Delete':
+        'Eliminar',
     'Saved!':
         '\u00A1Guardado!',
     'Delete Project':
-        'Borrar Proyecto',
+        'Eliminar proyecto',
     'Are you sure you want to delete':
-        '\u00BFEst\u00E1s seguro de que deseas borrar?',
+        '\u00BFEst\u00E1s seguro de que deseas eliminar',
     'rename...':
         'renombrar...',
+    'Cloud':
+        'Nube',
+    'Browser':
+        'Navegador',
+    'Examples':
+        'Ejemplos',
 
     // costume editor
     'Costume Editor':
         'Editor de disfraz',
     'click or drag crosshairs to move the rotation center':
-        'haz clic o arrastra punto de mira para mover el centro de rotaci\u00F3n',
+        'haz clic o arrastra el punto de mira\npara mover el centro de rotaci\u00F3n',
 
-    // project notes
+    // project notes dialog:
     'Project Notes':
         'Notas del proyecto',
 
-    // new project
+    // new project dialog:
     'New Project':
-        'Nuevo Proyecto',
+        'Nuevo proyecto',
     'Replace the current project with a new one?':
         '\u00BFReemplazar este proyecto con uno nuevo?',
-
-    // save project
-    'Save Project As...':
-        'Guardar Proyecto Como...',
 
     // export blocks
     'Export blocks':
@@ -1716,11 +1760,11 @@ SnapTranslator.dict.es = {
     'Apply':
         'Aplicar',
 
-    // block deletion dialog
+    // block deletion dialog:
     'Delete Custom Block':
-        'Borrar Bloque Personalizado',
+        'Eliminar bloque personalizado',
     'block deletion dialog text':
-        'texto de di\u00E1logo de borrado de bloque',
+        '\u00BFEst\u00E1s seguro de que quieres eliminar\neste bloque personalizado y todas sus instancias?',
 
     // input dialog
     'Create input name':
@@ -1808,7 +1852,7 @@ SnapTranslator.dict.es = {
 
     // coments
     'add comment here...':
-        'agregar comentario aqu\u00ED',
+        'añadir comentario aqu\u00ED...',
 
     //libraries
     'Tools':

--- a/lang-es.js
+++ b/lang-es.js
@@ -214,7 +214,7 @@ SnapTranslator.dict.es = {
     'Lists':
         'Listas',
     'Other':
-        'Otro',
+        'Otros',
 
     // editor:
     'don\'t rotate':
@@ -262,25 +262,25 @@ SnapTranslator.dict.es = {
     'undo':
         'deshacer',
     'Paintbrush tool\n(free draw)':
-        'Pincel\n(dibujo libre)',
+        'pincel\n(dibujo libre)',
     'Stroked Rectangle\n(shift: square)':
-        'Rect\u00E1ngulo\n(\u21E7 = cuadrado)',
+        'rect\u00E1ngulo\n(\u21E7 = cuadrado)',
     'Stroked Ellipse\n(shift: circle)':
-        'Elipse\n(\u21E7 = c\u00EDrculo)',
+        'elipse\n(\u21E7 = c\u00EDrculo)',
     'Eraser tool':
-        'Goma de borrar',
+        'goma de borrar',
     'Set the rotation center':
-        'Establecer centro de rotaci\u00F3n',
+        'establecer\ncentro de rotaci\u00F3n',
     'Line tool\n(shift: vertical/horizontal)':
-        'L\u00EDnea\n(\u21E7 = vertical/horizontal)',
+        'l\u00EDnea\n(\u21E7 = vertical/horizontal)',
     'Filled Rectangle\n(shift: square)':
-        'Rect\u00E1ngulo relleno\n(\u21E7 = cuadrado)',
+        'rect\u00E1ngulo relleno\n(\u21E7 = cuadrado)',
     'Filled Ellipse\n(shift: circle)':
-        'Elipse rellena\n(\u21E7 = c\u00EDrculo)',
+        'elipse rellena\n(\u21E7 = c\u00EDrculo)',
     'Fill a region':
-        'Bote de pintura',
+        'bote de pintura',
     'Pipette tool\n(pick a color anywhere)':
-        'Cuentagotas\n(obtiene colores de cualquier lugar)',
+        'cuentagotas\n(funciona dentro y fuera del editor)',
     'grow':
         'ampliar',
     'shrink':
@@ -316,11 +316,11 @@ SnapTranslator.dict.es = {
 
     // stage & sprite corral:
     'add a new Turtle sprite':
-        'a\u00F1adir una nueva tortuga',
+        'a\u00F1ade una nueva tortuga',
     'paint a new sprite':
-        'dibujar un nuevo objeto',
+        'dibuja un nuevo objeto',
     'take a camera snapshot and\nimport it as a new sprite':
-        'hacer una captura de c\u00E1mara\ne importarla como nuevo objeto',
+        'hace una captura de c\u00E1mara\n y la importa como nuevo objeto',
 
     // primitive blocks:
 
@@ -358,7 +358,7 @@ SnapTranslator.dict.es = {
     'development mode \ndebugging primitives:':
         'primitivas de depuraci\u00F3n\ndel modo desarrollador:',
     'find blocks':
-        'buscar bloques',
+        'busca bloques',
     'show primitives':
         'mostrar primitivas',
     'hide primitives':
@@ -533,13 +533,13 @@ SnapTranslator.dict.es = {
 
     // %inst values for (set instrument to %inst):
     '(1) sine':
-        '(1) \u223F\u223F onda sinusoidal',
+        '(1) \u223F\u223F (onda sinusoidal)',
     '(2) square':
-        '(2) \u238D\u238D onda cuadrada',
+        '(2) \u238D\u238D (onda cuadrada)',
     '(3) sawtooth':
-        '(3) \u2A58\u2A58 onda dentada',
+        '(3) \u2A58\u2A58 (onda dentada)',
     '(4) triangle':
-        '(4) \u22C0\u22C0 onda triangular',
+        '(4) \u22C0\u22C0 (onda triangular)',
 
     // pen:
     'clear':
@@ -606,6 +606,7 @@ SnapTranslator.dict.es = {
         'reportar %s',
     'stop %stopChoices':
         'detener %stopChoices',
+
     'run %cmdRing %inputs':
         'ejecutar %cmdRing %inputs',
     'launch %cmdRing %inputs':
@@ -620,6 +621,15 @@ SnapTranslator.dict.es = {
         'ejecutar %cmdRing con continuaci\u00F3n',
     'call %cmdRing w/continuation':
         'llamar %cmdRing con continuaci\u00F3n',
+    'with inputs':
+        'con argumentos',
+    'input names:':
+        'parámetros:',
+    'Input Names:':
+        'Nombres de entradas:',
+    'input list:':
+        'con lista de argumentos:',
+
     'when I start as a clone':
         'cuando comience como clon',
     'create a clone of %cln':
@@ -718,7 +728,7 @@ SnapTranslator.dict.es = {
         '9',
 
     // %interaction values for (when I am %interaction):
-    // In spanish read as "Cuando me %interaction"
+    // In spanish read as "cuando me %interaction"
     'clicked':
         'hagan clic',
     'pressed':
@@ -902,7 +912,7 @@ SnapTranslator.dict.es = {
     'not %b':
         'no %b',
     'true':
-        'cierto',
+        'verdadero',
     'false':
         'falso',
     'join %words':
@@ -936,9 +946,9 @@ SnapTranslator.dict.es = {
     'abs':
         'valor absoluto',
     'ceiling':
-        'redondeo por arriba',
+        'techo', // https://es.wikipedia.org/wiki/Funciones_de_parte_entera
     'floor':
-        'redondeo por abajo',
+        'suelo',
     'sqrt':
         'ra\u00EDz cuadrada',
     'sin':
@@ -1022,35 +1032,13 @@ SnapTranslator.dict.es = {
 
     // variables:
     'Make a variable':
-        'Crear una variable',
+        'Declarar variable',
     'Script variable name':
         'Nombre de variable de programa',
     'Variable name':
         'Nombre de variable',
     'Delete a variable':
-        'Borrar una variable',
-
-    'transient':
-        'excluir al guardar',
-    'uncheck to save contents\nin the project':
-        'desmarcar para guardar\nel contenido junto con el proyecto',
-    'check to prevent contents\nfrom being saved':
-        'marcar para no guardar\nel contenido junto con el proyecto',
-
-    'rename...':
-        'renombrar...',
-    'rename only\nthis reporter':
-        'renombra s\u00F3lo\neste reportero',
-    'rename all...':
-        'renombrar todos...',
-    'rename all blocks that\naccess this variable':
-        'renombra todos los bloques\nque acceden a esta variable',
-    'inherited':
-        'herencia',
-    'uncheck to\ndisinherit':
-        'desmarcar para no heredar',
-    'check to inherit\nfrom':
-        'marcar para heredar de',
+        'Borrar variable',
 
     'set %var to %s':
         'asignar a %var el valor %s',
@@ -1113,9 +1101,33 @@ SnapTranslator.dict.es = {
     'Table view':
         'Visor de tablas',
 
+    // variable watchers
+    'normal':
+        'normal',
+    'large':
+        'grande',
+    'slider':
+        'deslizador',
+    'slider min...':
+        'm\u00EDnimo valor del deslizador...',
+    'slider max...':
+        'm\u00E1ximo valor del deslizador...',
+    'import...':
+        'importar...',
+
+    // slider dialog:
+    'Slider minimum value':
+        'M\u00EDnimo valor del deslizador',
+    'Slider maximum value':
+        'M\u00E1ximo valor del deslizador',
+
+    // list watchers
+    'length: ':
+        'longitud: ',
+
     // other
     'Make a block':
-        'Crear un bloque',
+        'Crear bloque',
 
     // other development mode blocks:
     'code of %cmdRing':
@@ -1172,11 +1184,11 @@ SnapTranslator.dict.es = {
     'Switch back to user mode':
         'Regresar a modo usuario',
     'disable deep-Morphic\ncontext menus\nand show user-friendly ones':
-        'inhabilitar men\u0075s contextuales de Morphic\ny mostrar unos f\u00E1ciles de utilizar',
+        'desactiva los men\u0075s contextuales de Morphic\ny muestra unos más f\u00E1ciles de utilizar',
     'Switch to dev mode':
         'Cambiar a modo desarrollador',
     'enable Morphic\ncontext menus\nand inspectors,\nnot user-friendly!':
-        'habilitar men\u0075s contextuales\n e inspectores de Morphic,\n\u00A1no son f\u00E1ciles de utilizar!',
+        'activa los men\u0075s contextuales\n e inspectores de Morphic\n(\u00A1no son f\u00E1ciles de utilizar)',
     'entering development mode.\n\nerror catching is turned off,\nuse the browser\'s web console\nto see error messages.':
         'Se ha activado el modo desarrollador.\n\nEl cacheo de errores est\u00E1 desactivado,\nusa la consola del navegador\npara ver mensajes de error.',
     'entering user mode':
@@ -1197,7 +1209,7 @@ SnapTranslator.dict.es = {
     'Import...':
         'Importar...',
     'file menu import hint':
-        'importa proyectos, bloques,\nim\u00E1genes o sonidos',
+        'importa proyectos, bloques,\ndisfraces o sonidos',
 
     'Export project...':
         'Exportar proyecto...',
@@ -1219,7 +1231,7 @@ SnapTranslator.dict.es = {
     'Unused blocks...':
         'Bloques no utilizados...',
     'find unused global custom blocks\nand remove their definitions':
-        'busca bloques personalizados\nque no se est\u00E9n usando\ny borra sus definiciones',
+        'busca bloques personalizados\nque no se est\u00E9n siendo utilizados\ny borra sus definiciones',
 
     'Export summary...':
         'Exportar resumen...',
@@ -1229,7 +1241,7 @@ SnapTranslator.dict.es = {
     'Export summary with drop-shadows...':
         'Exportar resumen (im\u00E1genes con sombra)...',
     'open a new browser browser window\nwith a summary of this project\nwith drop-shadows on all pictures.\nnot supported by all browsers':
-        'muestra un resumen de este proyecto\ndonde las im\u00E1genes tienen sombra\nen una nueva ventana del navegador.\nno funciona en todos los navegadores',
+        'muestra un resumen de este proyecto\ndonde las im\u00E1genes tienen sombra\nen una nueva ventana del navegador\n(no funciona en todos los navegadores)',
 
     'Export all scripts as pic...':
         'Exportar todos los programas como imagen',
@@ -1360,7 +1372,7 @@ SnapTranslator.dict.es = {
     'User name must be four\ncharacters or longer':
         'el nombre de usuario ha de tener\ncomo m\u00EDnimo 4 caracteres',
     'please provide a valid\nemail address':
-        'por favor, proporciona\nuna direcci\u00F3n de correo v\u00E1lida',
+        'por favor, escribe\nuna direcci\u00F3n de correo v\u00E1lida',
     'password must be six\ncharacters or longer':
         'la contrase\u00F1a ha de tener\ncomo m\u00EDnimo 6 caracteres',
     'passwords do\nnot match':
@@ -1417,7 +1429,7 @@ SnapTranslator.dict.es = {
     'Language...':
         'Idioma...',
     'Zoom blocks...':
-        'Agrandar bloques...',
+        'Tama\u00F1o de bloque...',
     'Stage size...':
         'Tama\u00F1o del escenario...',
 
@@ -1464,7 +1476,7 @@ SnapTranslator.dict.es = {
     'Ternary Boolean slots':
         'Huecos booleanos triestado',
     'uncheck to limit\nBoolean slots to true / false':
-        'desmarcar para restringir\nlos huecos booleanos a cierto / falso',
+        'desmarcar para restringir\nlos huecos booleanos a verdadero / falso',
     'check to allow\nempty Boolean slots':
         'marcar para permitir\nhuecos booleanos vac\u00EDos',
 
@@ -1483,18 +1495,18 @@ SnapTranslator.dict.es = {
         'marcar para usar sombras\ny brillos difuminados',
 
     'Zebra coloring':
-        'Coloraci\u00F3n de cebra',
+        'Coloreado de cebra',
     'check to enable alternating\ncolors for nested blocks':
-        'marcar para habilitar alternaci\u00F3n\nde colores para bloques anidados',
+        'marcar para activar\nla alternaci\u00F3n\nde colores\npara bloques anidados',
     'uncheck to disable alternating\ncolors for nested block':
-        'desmarcar para inhabilitar alternaci\u00F3n\nde colores para bloques anidados',
+        'desmarcar para desactivar\nla alternaci\u00F3n de colores\npara bloques anidados',
 
     'Dynamic input labels':
         'Etiquetas de entrada din\u00E1micas',
     'uncheck to disable dynamic\nlabels for variadic inputs':
-        'desmarcar para inhabilitar etiquetas\ndin\u00E1micas para entradas variables',
+        'desmarcar para desactivar\nlas etiquetas din\u00E1micas\npara entradas variables',
     'check to enable dynamic\nlabels for variadic inputs':
-        'marcar para habilitar etiquetas\ndin\u00E1micas para entradas variables',
+        'marcar para activar\nlas etiquetas din\u00E1micas\npara entradas variables',
 
     'Prefer empty slot drops':
         'Dar preferencia a huecos vac\u00EDos',
@@ -1520,9 +1532,9 @@ SnapTranslator.dict.es = {
     'Virtual keyboard':
         'Teclado virtual',
     'uncheck to disable\nvirtual keyboard support\nfor mobile devices':
-        'desmarcar para inhabilitar\nel soporte del teclado virtual\npara dispositivos m\u00F3viles',
+        'desmarcar para desactivar\nel soporte de teclado virtual\npara dispositivos m\u00F3viles',
     'check to enable\nvirtual keyboard support\nfor mobile devices':
-        'marcar para habilitar\nel soporte del teclado virtual\npara dispositivos m\u00F3viles',
+        'marcar para activar\nel soporte de teclado virtual\npara dispositivos m\u00F3viles',
 
     'Clicking sound':
         'Sonido de clic',
@@ -1534,9 +1546,9 @@ SnapTranslator.dict.es = {
     'Animations':
         'Animaciones',
     'uncheck to disable\nIDE animations':
-        'desmarcar para inhabilitar\nanimaciones del IDE',
+        'desmarcar para desactivar\nlas animaciones del IDE',
     'check to enable\nIDE animations':
-        'marcar para habilitar\nanimaciones del IDE',
+        'marcar para activar\nlas animaciones del IDE',
 
     'Cache Inputs':
         'Cachear entradas',
@@ -1548,7 +1560,7 @@ SnapTranslator.dict.es = {
     'Rasterize SVGs':
         'Rasterizar SVGs',
     'uncheck for smooth\nscaling of vector costumes':
-        'desmarcar para usar\nescalado suave en im\u00E1genes vectoriales',
+        'desmarcar para usar escalado suave\nen im\u00E1genes vectoriales',
     'check to rasterize\nSVGs on import':
         'marcar para rasterizar los SVGs\ntras haberlos importado',
 
@@ -1562,16 +1574,16 @@ SnapTranslator.dict.es = {
     'Nested auto-wrapping':
         'Encapsular bloques internos',
     'uncheck to confine auto-wrapping\nto top-level block stacks':
-        'desmarcar para que bloques tipo C\nsolo puedan encapsular a otros m\u00E1s externos',
+        'desmarcar para que bloques tipo C\nsólo puedan encapsular a otros m\u00E1s externos',
     'check to enable auto-wrapping\ninside nested block stacks':
         'marcar para permitir que bloques tipo C\npuedan encapsular a otros m\u00E1s internos',
 
     'Project URLs':
-        'URLs de proyecto',
+        'URLs con datos de proyecto',
     'uncheck to disable\nproject data in URLs':
-        'desmarcar para no incluir\ndatos de proyecto en las URLs',
+        'desmarcar para no incluir\ndatos del proyecto en las URLs',
     'check to enable\nproject data in URLs':
-        'marcar para incluir\ndatos de proyecto en las URLs',
+        'marcar para incluir\ndatos del proyecto en las URLs',
 
     'Sprite Nesting':
         'Anidamiento de objetos',
@@ -1583,16 +1595,16 @@ SnapTranslator.dict.es = {
     'First-Class Sprites':
         'Objetos de primera clase',
     'uncheck to disable support\nfor first-class sprites':
-        'desmarcar para inhabilitar el\nsoporte para objectos de primera clase',
+        'desmarcar para desactivar\nel soporte de objetos de primera clase',
     'check to enable support\n for first-class sprite':
-        'marcar para habilitar el\nsoporte para objectos de primera clase',
+        'marcar para activar\nel soporte de objetos de primera clase',
 
     'Keyboard Editing':
         'Edici\u00F3n de teclado',
     'uncheck to disable\nkeyboard editing support':
-        'desmarcar para inhabilitar\nel soporte de edici\u00F3n de teclado',
+        'desmarcar para desactivar\nel soporte de edici\u00F3n de teclado',
     'check to enable\nkeyboard editing support':
-        'marcar para habilitar\nel soporte de edici\u00F3n de teclado',
+        'marcar para activar\nel soporte de edici\u00F3n de teclado',
 
     'Table support':
         'Soporte para tablas',
@@ -1611,12 +1623,12 @@ SnapTranslator.dict.es = {
     'Live coding support':
         'Soporte para programaci\u00F3n en vivo',
     'EXPERIMENTAL! uncheck to disable live\ncustom control structures':
-        '\u00A1EXPERIMENTAL! desmarcar para inhabilitar las\nestructuras de control personalizadas en vivo',
+        '\u00A1EXPERIMENTAL! desmarcar para desactivar las\nestructuras de control personalizadas en vivo',
     'EXPERIMENTAL! check to enable\n live custom control structures':
-        '\u00A1EXPERIMENTAL! marcar para habilitar las\nestructuras de control personalizadas en vivo',
+        '\u00A1EXPERIMENTAL! marcar para activar las\nestructuras de control personalizadas en vivo',
 
     'Thread safe scripts':
-        'Programas seguros para uso paralelo',
+        'Hilos de ejecución seguros',
     'uncheck to allow\nscript reentrance':
         'desmarcar para permitir\nla reentrada de programas',
     'check to disallow\nscript reentrance':
@@ -1625,16 +1637,16 @@ SnapTranslator.dict.es = {
     'Prefer smooth animations':
         'Preferir animaciones suaves',
     'uncheck for greater speed\nat variable frame rates':
-        'desmarcar para mayor velocidad\na cuadros por segundo variables',
+        'desmarcar para una mayor velocidad\na cuadros por segundo variables',
     'check for smooth, predictable\nanimations across computers':
-        'marcar para animaciones suaves y predecibles entre ordenadores',
+        'marcar para unas animaciones suaves\ny predecibles entre ordenadores',
 
     'Flat line ends':
         'Extremos de l\u00EDnea rectos',
     'uncheck for round ends of lines':
-        'desmarcar para dibujar l\u00EDneas\ncon extremos redondeados',
+        'desmarcar para dibujar\nl\u00EDneas con extremos redondeados',
     'check for flat ends of lines':
-        'marcar para dibujar l\u00EDneas\ncon extremos rectos',
+        'marcar para dibujar\nl\u00EDneas con extremos rectos',
 
     'Codification support':
         'Soporte de codificaci\u00F3n',
@@ -1659,7 +1671,7 @@ SnapTranslator.dict.es = {
 
     // zoom blocks dialog
     'Zoom blocks':
-        'Agrandar bloques',
+        'Tamaño de bloque',
     'build':
         'construye',
     'your own':
@@ -1675,13 +1687,13 @@ SnapTranslator.dict.es = {
     'big (2x)':
         'grande (2x)',
     'huge (4x)':
-        'inmenso (4x)',
+        'enorme (4x)',
     'giant (8x)':
         'gigantesco (8x)',
     'monstrous (10x)':
         'monstruoso (10x)',
 
-    // stage size dialog
+    // stage size dialog:
     'Stage size':
         'Tama\u00F1o del escenario',
     'Stage width':
@@ -1689,25 +1701,15 @@ SnapTranslator.dict.es = {
     'Stage height':
         'Altura del escenario',
 
-    // dragging threshold dialog
+    // dragging threshold dialog:
     'Dragging threshold':
         'Umbral de arrastre',
 
-    // inputs
-    'with inputs':
-        'con entradas',
-    'input names:':
-        'nombres de entradas:',
-    'Input Names:':
-        'Nombres de entradas:',
-    'input list:':
-        'lista de entradas:',
-
-    // context menus:
+    // context menu:
     'help':
         'ayuda',
 
-    // blocks context menus:
+    // blocks context menu:
     'help...':
         'ayuda...',
     'relabel...':
@@ -1719,7 +1721,7 @@ SnapTranslator.dict.es = {
     'only duplicate this block':
         'duplica s\u00F3lo este bloque',
     'delete':
-        'borrar',
+        'eliminar',
 
     'script pic...':
         'imagen de programa...',
@@ -1734,7 +1736,7 @@ SnapTranslator.dict.es = {
     'script pic with result...':
         'imagen de programa con resultado...',
     'open a new window\nwith a picture of both\nthis script and its result':
-        'abre una nueva ventana\ncon una imagen de este programa y su resultado',
+        'abre una nueva ventana\ncon una imagen de este programa\ny su resultado',
 
     'ringify':
         'encapsular',
@@ -1758,7 +1760,7 @@ SnapTranslator.dict.es = {
     'Enter code that corresponds to the block\'s operation (usually a single\nfunction invocation). Use <#n> to reference actual arguments as shown.':
         'Escribe el c\u00F3digo correspondiente a la implementaci\u00F3n del bloque\n(normalmente una \u00FAnica llamada a funci\u00F3n).\nUsa <#n> para referenciar los argumentos aqu\u00ED mostrados.',
 
-    // custom blocks context menus:
+    // custom blocks context menu:
     'delete block definition...':
         'eliminar definici\u00F3n de bloque...',
     'edit...':
@@ -1776,7 +1778,7 @@ SnapTranslator.dict.es = {
     'experimental -\nunder construction':
         'experimental\n(en construcci\u00F3n)',
 
-    // sprites:
+    // sprites context menu:
     'edit':
         'editar',
     'rotate':
@@ -1795,6 +1797,8 @@ SnapTranslator.dict.es = {
         'liberar',
     'make temporary and\nhide in the sprite corral':
         'lo hace temporal y oculta\nen el corral de objetos',
+    'make permanent and\nshow in the sprite corral':
+        'lo hace permanente y\nlo muestra en el corral de objetos',
     'detach from':
         'desvincular de',
     'detach all parts':
@@ -1802,13 +1806,15 @@ SnapTranslator.dict.es = {
     'export...':
         'exportar...',
 
-    // stage:
+    // stage context menu:
     'show all':
         'mostrar todos',
+
     'pic...':
         'imagen...',
     'open a new window\nwith a picture of the stage':
         'abre una nueva ventana\ncon una imagen del escenario',
+
     'pen trails':
         'rastro del l\u00E1piz',
     'turn all pen trails and stamps\ninto a new costume for the\ncurrently selected sprite':
@@ -1816,33 +1822,43 @@ SnapTranslator.dict.es = {
     'turn all pen trails and stamps\ninto a new background for the stage':
         'convierte todo rastro del l\u00E1piz\nen un nuevo fondo para el escenario',
 
-    // scripting area:
+    // scripting area context menu:
     'undrop':
         'deshacer',
     'undo the last\nblock drop\nin this pane':
         'deshace el \u00FAltimo cambio\nhecho con bloques',
+
     'redrop':
         'rehacer',
     'redo the last undone\nblock drop\nin this pane':
         'rehace el \u00FAltimo cambio\ndeshecho con bloques',
+
     'clear undrop queue':
         'vaciar historial de cambios',
     'forget recorded block drops\non this pane':
         'olvida el historial\nde cambios hechos con bloques',
+
     'clean up':
         'ordenar',
     'arrange scripts\nvertically':
         'alinea los programas\nverticalmente',
+
     'add comment':
         'a\u00F1adir comentario',
+    // comment default text:
+    'add comment here...':
+        'a\u00F1adir comentario aqu\u00ED...',
+
     'scripts pic...':
         'imagen de programas...',
     'open a new window\nwith a picture of all scripts':
         'abre una nueva ventana\ncon una imagen de todos los programas',
+
     'make a block...':
         'crear bloque...',
+
     'use the keyboard\nto enter blocks':
-        'usar el teclado\npara escribir bloques',
+        'permite utilizar el teclado\npara escribir bloques',
 
     // costumes
     'rename':
@@ -1868,6 +1884,29 @@ SnapTranslator.dict.es = {
     'Stop sound':
         'detiene este sonido',
 
+    // variables context menu
+    'transient':
+        'excluir al guardar',
+    'uncheck to save contents\nin the project':
+        'desmarcar para guardar\nel contenido junto con el proyecto',
+    'check to prevent contents\nfrom being saved':
+        'marcar para no guardar\nel contenido junto con el proyecto',
+
+    'rename...':
+        'renombrar...',
+    'rename only\nthis reporter':
+        'renombra s\u00F3lo\neste reportero',
+    'rename all...':
+        'renombrar todos...',
+    'rename all blocks that\naccess this variable':
+        'renombra todos los bloques\nque acceden a esta variable',
+    'inherited':
+        'herencia',
+    'uncheck to\ndisinherit':
+        'desmarcar para no heredar',
+    'check to inherit\nfrom':
+        'marcar para heredar de',
+
     // lists context menu
     'items':
         'elementos',
@@ -1890,27 +1929,27 @@ SnapTranslator.dict.es = {
     'rename sound':
         'Renombrar sonido',
 
-    // comments context menu
+    // comments context menu:
     'comment pic...':
         'imagen de comentario...',
     'open a new window\nwith a picture of this comment':
         'abre una nueva ventana\ncon una imagen de este comentario',
 
-    // morph context menu
+    // morph context menu:
     'user features':
-        'men\u00FA de usuario',
+        'opciones de usuario',
 
     'color...':
         'color...',
     '\ncolor:':
         '\ncolor:',
     'choose another color \nfor this morph':
-        'elige otro color\npara este morph',
+        'cambia el color\nde este morph',
 
     'transparency...':
         'transparencia...',
     '\nalpha\nvalue:':
-        'valor alfa',
+        '\nvalor alfa',
     'set this morph\'s\nalpha value':
         'establece el valor alfa\nde este morph',
 
@@ -1976,16 +2015,17 @@ SnapTranslator.dict.es = {
         'rotar',
     'interactively turn this morph\nusing a dial widget':
         'gira este morph\nutilizando un control de disco',
+
     'edit rotation point only...':
         'editar s\u00F3lo punto de rotaci\u00F3n...',
+
     'pivot':
         'pivote',
     'edit the costume\'s\nrotation center':
         'edita el centro\nde rotaci\u00F3n del disfraz',
+
     'edit':
         'editar',
-    'make permanent and\nshow in the sprite corral':
-        'lo hace permanente y\nlo muestra en el corral de objetos',
 
     'move all inside...':
         'mover todos dentro...',
@@ -2063,7 +2103,7 @@ SnapTranslator.dict.es = {
         'restaurar pantalla',
     'redraw the\nscreen once':
         'redibuja la pantalla',
-    "fill page...":
+    'fill page...':
         'llenar p\u00E1gina',
     'let the World automatically\nadjust to browser resizing':
         'hace que el Mundo se ajuste\nautom\u00E1ticamente cuando\nse redimensiona el navegador', // @todo
@@ -2132,7 +2172,7 @@ SnapTranslator.dict.es = {
     'pen':
         'tortuga',
 
-    // custom block text fragment symbols
+    // custom block's text fragment symbols:
     'square':
         'cuadrado',
     'pointRight':
@@ -2254,6 +2294,8 @@ SnapTranslator.dict.es = {
         'Aceptar',
     'Cancel':
         'Cancelar',
+    'Apply':
+        'Aplicar',
     'Default':
         'Predeterminado',
     'Yes':
@@ -2269,7 +2311,7 @@ SnapTranslator.dict.es = {
     'Untitled':
         'Sin T\u00EDtulo',
     'Open Project':
-        'Abrir Proyecto',
+        'Abrir proyecto',
     'Save Project':
         'Guardar proyecto',
     'Save Project As...':
@@ -2294,8 +2336,8 @@ SnapTranslator.dict.es = {
         '\u00A1Guardado!',
     'Delete Project':
         'Eliminar proyecto',
-    'Are you sure you want to delete':
-        '\u00BFEst\u00E1s seguro de que deseas eliminar',
+    'Are you sure you want to delete': // + proyect name?
+        '\u00BFSeguro que quieres eliminar', // + proyect name?
     'Cloud':
         'Nube',
     'Browser':
@@ -2310,28 +2352,28 @@ SnapTranslator.dict.es = {
         'Guardado.',
     'last changed':
         '\u00FAltima modificaci\u00F3n',
-    'Are you sure you want to share':
-        '\u00BFEst\u00E1s seguro de que\nquieres compartir',
-    'Are you sure you want to unshare':
-        '\u00BFEst\u00E1s seguro de que\nquieres dejar de compartir',
+    'Are you sure you want to share': // + project name?
+        '\u00BFSeguro que quieres\ncompartir', // + project name?
+    'Are you sure you want to unshare': // + project name?
+        '\u00BFSeguro que quieres\ndejar de compartir', // + project name?
     'sharing\nproject...':
-        'compartiendo proyecto...',
+        'Compartiendo proyecto...',
     'shared.':
-        'compartido.',
+        'Compartido.',
     'unsharing\nproject...':
-        'dejando de compartir...',
+        'Dejando de compartir...',
     'unshared.':
-        'no compartido.',
+        'No compartido.',
     'Are you sure you want to publish':
-        '\u00BFEst\u00E1s seguro de que\nquieres publicar',
+        '\u00BFSeguro que quieres\npublicar', // + project name?
     'Are you sure you want to unpublish':
-        '\u00BFEst\u00E1s seguro de que\nquieres dejar de publicar',
+        '\u00BFSeguro que quieres\ndejar de publicar', // + project name?
     'Publish Project':
         'Publicar proyecto',
     'Unpublish Project':
         'Dejar de publicar',
     'publishing\nproject...':
-        'Publicando\nproyecto...',
+        'Publicando proyecto...',
     'unpublishing\nproject...':
         'Cancelando publicaci\u00F3n...',
     'published.':
@@ -2339,9 +2381,9 @@ SnapTranslator.dict.es = {
     'unpublished.':
         'No publicado',
 
-    // costume editor
+    // costume editor @todo (wasn't this superseed by paint editor?)
     'Costume Editor':
-        'Editor de disfraz',
+        'Editor de disfraces',
     'click or drag crosshairs to move the rotation center':
         'haz clic o arrastra el punto de mira\npara mover el centro de rotaci\u00F3n',
 
@@ -2353,7 +2395,7 @@ SnapTranslator.dict.es = {
     'New Project':
         'Nuevo proyecto',
     'Replace the current project with a new one?':
-        '\u00BFReemplazar este proyecto con uno nuevo?',
+        '\u00BFSeguro que quieres\ndescartar el actual proyecto\ny empezar un proyecto nuevo?',
 
     // export blocks
     'Export blocks':
@@ -2362,6 +2404,8 @@ SnapTranslator.dict.es = {
         'Importar bloques',
     'this project doesn\'t have any\ncustom global blocks yet':
         'este proyecto no tiene ning\u00FAn bloque personalizado todav\u00EDa',
+    'no blocks were selected':
+        'No se ha seleccionado ningún bloque',
     'select':
         'seleccionar',
     'all':
@@ -2375,7 +2419,11 @@ SnapTranslator.dict.es = {
     'for this sprite only':
         's\u00F3lo para este objeto',
 
-    // block dialog
+    // block editor dialog:
+    'Block Editor':
+        'Editor de bloques',
+    'Method Editor':
+        'Editor de m\u00E9todos',
     'Change block':
         'Cambiar bloque',
     'Command':
@@ -2384,14 +2432,6 @@ SnapTranslator.dict.es = {
         'Reportero',
     'Predicate':
         'Predicado',
-
-    // block editor
-    'Block Editor':
-        'Editor de bloques',
-    'Method Editor':
-        'Editor de m\u00E9todos',
-    'Apply':
-        'Aplicar',
     'block variables':
         'variables de bloque',
 
@@ -2405,7 +2445,7 @@ SnapTranslator.dict.es = {
     'Delete Custom Block':
         'Eliminar bloque personalizado',
     'block deletion dialog text':
-        '\u00BFEst\u00E1s seguro de que quieres eliminar\neste bloque personalizado y todas sus instancias?',
+        '\u00BFSeguro que quieres eliminar\neste bloque personalizado\ny todas sus instancias?',
 
     // input dialog:
     'Create input name':
@@ -2419,7 +2459,7 @@ SnapTranslator.dict.es = {
     'Input name':
         'Par\u00E1metro',
     'Delete':
-        'Borrar',
+        'Eliminar',
 
     'Object':
         'Objeto',
@@ -2440,7 +2480,7 @@ SnapTranslator.dict.es = {
     'Predicate':
         'Predicado',
     'Command\n(C-shape)':
-        'Comando\n(forma C)',
+        'Comando\n(tipo C)',
     'Any\n(unevaluated)':
         'Cualquier tipo\n(no evaluado)',
     'Boolean\n(unevaluated)':
@@ -2458,7 +2498,7 @@ SnapTranslator.dict.es = {
     'Input Slot Options':
         'Opciones de par\u00E1metro de entrada',
     'Enter one option per line.\nOptionally use "=" as key/value delimiter and {} for submenus. e.g.\n   the answer=42':
-        'Escribe cada opci\u00F3n en una l\u00EDnea.\nUsa "=" para asignar un valor y {} para submen\u00FAs, por ejemplo:\n  respuesta=42',
+        'Escribe cada opci\u00F3n en una l\u00EDnea.\nUsa (=) para asignar un valor y {} para submen\u00FAs, por ejemplo:\n  respuesta=42',
 
     // About Snap
     'About Snap':
@@ -2472,45 +2512,17 @@ SnapTranslator.dict.es = {
     'Credits...':
         'Créditos...',
     'Translators...':
-        'Traductores',
+        'Traductores...',
     'License':
         'Licencia',
     'current module versions:':
-        'versiones del m\u00F3dulo actual',
+        'Versiones actuales de los m\u00F3dulos:',
     'Contributors':
         'Colaboradores',
     'Translations':
         'Traducciones',
 
-    // variable watchers
-    'normal':
-        'normal',
-    'large':
-        'grande',
-    'slider':
-        'deslizador',
-    'slider min...':
-        'm\u00EDnimo valor del deslizador...',
-    'slider max...':
-        'm\u00E1ximo valor del deslizador...',
-    'import...':
-        'importar...',
-
-    // slider dialog:
-    'Slider minimum value':
-        'M\u00EDnimo valor del deslizador',
-    'Slider maximum value':
-        'M\u00E1ximo valor del deslizador',
-
-    // list watchers
-    'length: ':
-        'longitud: ',
-
-    // coments
-    'add comment here...':
-        'a\u00F1adir comentario aqu\u00ED...',
-
-    // exported summary
+    // exported summary in HTML:
     'Contents':
         'Contenido',
     'Kind of':
@@ -2536,7 +2548,7 @@ SnapTranslator.dict.es = {
     'Could not export':
         'No se ha podido exportar',
     'unable to export text':
-        'no se ha podido exportar el texto',
+        'No se ha podido exportar el texto',
 
     //libraries
     'Tools':
@@ -2627,7 +2639,7 @@ SnapTranslator.dict.es = {
     'analyze, manipulate and generate sound samples.':
         'analiza, manipula y genera muestras de sonido',
 
-    // library dialog
+    // library dialog:
     'Import library':
         'Importar biblioteca',
     'Import':
@@ -2637,7 +2649,7 @@ SnapTranslator.dict.es = {
     'Loading':
         'Cargando',
 
-    // threads.js
+    // need to be relocated:
     'expecting':
         'se esperaban las entradas',
     'input(s), but getting':

--- a/locale.js
+++ b/locale.js
@@ -288,11 +288,11 @@ SnapTranslator.dict.es = {
     'language_name':
         'Espa\u00F1ol',
     'language_translator':
-        'V\u00EDctor Manuel Muratalla Morales',
+        'V\u00EDctor Manuel Muratalla Morales / Cristi\u00E1n Rizzi Iribarren / Alfonso Ruzafa',
     'translator_e-mail':
-        'victor.muratalla@yahoo.com',
+        'victor.muratalla@yahoo.com / rizzi.cristian@gmail.com',
     'last_changed':
-        '2018-01-22'
+        '2018-02-19'
 };
 
 SnapTranslator.dict.nl = {


### PR DESCRIPTION
Hi.

I've working on a more accurated translation of Snap! into spanish, keeping the focus on these points:

Provide missing translations for:
  * ide
  * dialogs
  * menus
  * popup messages
  * libraries
  * development mode stuff

Keep related translations ordered and together .

Turn unintuitive/literal/wrong translations in a more natural fashion.

Remove deprecated and duplicated translations.

