### PR TITLE
Changed reset password and resend verification dialog texts

### DIFF
--- a/gui.js
+++ b/gui.js
@@ -5263,7 +5263,7 @@ IDE_Morph.prototype.resetCloudPassword = function () {
                     new DialogBoxMorph().inform(
                         title,
                         txt +
-                            '.\n\nAn e-mail with a link to\n' +
+                            '\n\nAn e-mail with a link to\n' +
                             'reset your password\n' +
                             'has been sent to the address provided',
                         world,
@@ -5299,10 +5299,7 @@ IDE_Morph.prototype.resendVerification = function () {
                 function (txt, title) {
                     new DialogBoxMorph().inform(
                         title,
-                        txt +
-                            '.\n\nAn e-mail with a link to\n' +
-                            'verify your account\n' +
-                            'has been sent to the address provided',
+                        txt,
                         world,
                         myself.cloudIcon(null, new Color(0, 180, 0))
                     );


### PR DESCRIPTION
This was happening:

![image](https://user-images.githubusercontent.com/1016697/36535135-f8307786-17c8-11e8-937b-23f02eb065fe.png)

When trying to re-verify an already verified user, we are just informing the user and not sending any emails, so I removed the part that Snap! was adding to the message returned by the backend.

It now looks like this:

![image](https://user-images.githubusercontent.com/1016697/36535192-275fbb5c-17c9-11e8-92b2-fd3c79df1144.png)

If we want to add more text, we should do that in the backend side.

I also removed the extra dot from the reset password dialog.