### PR TITLE
Fixing issue #2032, storing and loading comments anchored to variable blocks

### DIFF
--- a/store.js
+++ b/store.js
@@ -1101,10 +1101,10 @@ SnapSerializer.prototype.loadBlock = function (model, isReporter, object) {
                 model.attributes,
                 'var'
             )) {
-            return SpriteMorph.prototype.variableBlock(
+            block = SpriteMorph.prototype.variableBlock(
                 model.attributes['var']
             );
-        }
+        } else {
         /*
         // disable JavaScript functions, commented out for now
         if (model.attributes.s === 'reportJSFunction' &&
@@ -1116,10 +1116,11 @@ SnapSerializer.prototype.loadBlock = function (model, isReporter, object) {
             }
         }
         */
-        block = SpriteMorph.prototype.blockForSelector(model.attributes.s);
-        migration = SpriteMorph.prototype.blockMigrations[model.attributes.s];
-        if (migration) {
-            migrationOffset = migration.offset;
+            block = SpriteMorph.prototype.blockForSelector(model.attributes.s);
+            migration = SpriteMorph.prototype.blockMigrations[model.attributes.s];
+            if (migration) {
+                migrationOffset = migration.offset;
+            }
         }
     } else if (model.tag === 'custom-block') {
         isGlobal = model.attributes.scope ? false : true;
@@ -1913,10 +1914,20 @@ BlockMorph.prototype.toBlockXML = function (serializer) {
 };
 
 ReporterBlockMorph.prototype.toXML = function (serializer) {
-    return this.selector === 'reportGetVar' ? serializer.format(
-        '<block var="@"/>',
-        this.blockSpec
-    ) : this.toBlockXML(serializer);
+    if (this.selector === 'reportGetVar') {
+        if (!this.comment) {
+            return serializer.format(
+                '<block var="@"/>',
+                this.blockSpec);
+        } else {
+            return serializer.format(
+                '<block var="@">%</block>',
+                this.blockSpec,
+                this.comment.toXML(serializer));
+        }
+    } else {
+        return this.toBlockXML(serializer);
+    }
 };
 
 ReporterBlockMorph.prototype.toScriptXML = function (


### PR DESCRIPTION
Related to issue #2032.

Two changes:
- Serializing blocks, if a _variable block_ have comments anchored, change the format `<block var="@"/>` to `<block var="@">%</block>` putting _comments_ in `%`
- Loading serialized blocks, it takes care if _variable blocks_ have comments anchored.