### PR TITLE
Add a CSP to upgrade http requests to https

### DIFF
--- a/snap.html
+++ b/snap.html
@@ -2,6 +2,7 @@
 <html>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
 		<title>Snap! Build Your Own Blocks 4.1.2.2</title>
 		<link rel="shortcut icon" href="favicon.ico">
 		<script type="text/javascript" src="morphic.js?version=2018-02-20"></script>


### PR DESCRIPTION
This will make it easier for existing projects that add images or JS libraries and, AFAIK, request http projects to load things when snap is served over https. 

**TODO**
When/If we serve snap.html over a plan http connection, we need to see if this also upgrades requests to local servers that aren't going to have SSL.