### PR TITLE
Update the domain to cloud.snap.berkeley.edu

### DIFF
--- a/cloud.js
+++ b/cloud.js
@@ -32,7 +32,7 @@
 /*global modules, SnapSerializer, nop, hex_sha512, DialogBoxMorph, Color,
 normalizeCanvas*/
 
-modules.cloud = '2018-February-20';
+modules.cloud = '2018-March-02';
 
 // Global stuff
 
@@ -50,7 +50,7 @@ Cloud.prototype.init = function (url) {
     this.username = null;
 };
 
-SnapCloud = new Cloud('https://snap-cloud.cs10.org');
+SnapCloud = new Cloud('https://cloud.snap.berkeley.edu');
 
 // Dictionary handling
 

--- a/gui.js
+++ b/gui.js
@@ -5573,9 +5573,10 @@ IDE_Morph.prototype.setCloudURL = function () {
         this.world(),
         null,
         {
-            'Snap!Cloud' : 'https://snap-cloud.cs10.org',
+            'Snap!Cloud' : 'https://cloud.snap.berkeley.edu',
+            'Snap!Cloud (cs10)' : 'https://snap-cloud.cs10.org',
             'localhost' : 'http://localhost:8080',
-            'localhost (secure)' : 'https://localhost:8080'
+            'localhost (secure)' : 'https://localhost:4431'
         }
     );
 };

--- a/gui.js
+++ b/gui.js
@@ -75,7 +75,7 @@ isRetinaSupported, SliderMorph, Animation, BoxMorph, MediaRecorder*/
 
 // Global stuff ////////////////////////////////////////////////////////
 
-modules.gui = '2018-February-22';
+modules.gui = '2018-March-02';
 
 // Declarations
 

--- a/snap.html
+++ b/snap.html
@@ -9,7 +9,7 @@
 		<script type="text/javascript" src="blocks.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="threads.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="objects.js?version=2018-02-20"></script>
-		<script type="text/javascript" src="gui.js?version=2018-02-20"></script>
+		<script type="text/javascript" src="gui.js?version=2018-03-02"></script>
 		<script type="text/javascript" src="paint.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="lists.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="byob.js?version=2018-02-20"></script>
@@ -18,7 +18,7 @@
 		<script type="text/javascript" src="xml.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="store.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="locale.js?version=2018-02-20"></script>
-		<script type="text/javascript" src="cloud.js?version=2018-02-20"></script>
+		<script type="text/javascript" src="cloud.js?version=2018-03-02"></script>
 		<script type="text/javascript" src="sha512.js?version=2018-02-20"></script>
 		<script type="text/javascript" src="FileSaver.min.js?version=2018-02-20"></script>
 		<script type="text/javascript">


### PR DESCRIPTION
- updates querystrings
- Also updates the domains picker for the cloud.
- the https one was broken before. (4431 is a port that works in development)