### PR TITLE
Programmatic declaration of permanent variables

### DIFF
--- a/blocks.js
+++ b/blocks.js
@@ -1072,6 +1072,18 @@ SyntaxElementMorph.prototype.labelPart = function (spec) {
                 true // read-only
             );
             break;
+        case '%vartype':
+            part = new InputSlotMorph(
+                null, // text
+                false, // numeric?
+                {
+                    'script' : ['script'],
+                    'sprite-local' : ['sprite-local'],
+                    'global' : ['global']
+                },
+                true // read-only
+            );
+            break;
         case '%spr':
             part = new InputSlotMorph(
                 null,

--- a/objects.js
+++ b/objects.js
@@ -1123,7 +1123,8 @@ SpriteMorph.prototype.initBlocks = function () {
         doDeclareVariables: {
             type: 'command',
             category: 'other',
-            spec: 'script variables %scriptVars'
+            spec: '%vartype variables %scriptVars',
+	    defaults: ['script']
         },
 
         // inheritance - experimental

--- a/threads.js
+++ b/threads.js
@@ -1445,11 +1445,21 @@ Process.prototype.evaluateCustomBlock = function () {
 
 // Process variables primitives
 
-Process.prototype.doDeclareVariables = function (varNames) {
-    var varFrame = this.context.outerContext.variables;
-    varNames.asArray().forEach(function (name) {
-        varFrame.addVar(name);
-    });
+Process.prototype.doDeclareVariables = function (type, varNames) {
+	if (type == 'script') {
+	    var varFrame = this.context.outerContext.variables;
+    	varNames.asArray().forEach(function (name) {
+        	varFrame.addVar(name);
+	    });
+	} else {
+		var rcvr = this.blockReceiver();
+        varNames.asArray().forEach(function (name) {
+			rcvr.addVariable(name, (type == 'global'));
+		});
+        var ide = rcvr.parentThatIsA(IDE_Morph);
+        ide.flushBlocksCache('variables'); // b/c of inheritance
+        ide.refreshPalette();
+	};
 };
 
 Process.prototype.doSetVar = function (varName, value) {


### PR DESCRIPTION
Modifies the SCRIPT VARIABLES block so that it can be changed into
GLOBAL VARIABLES or SPRITE-LOCAL VARIABLES.

The purpose is for libraries that want to initialize variables for
later use by the user of the library.  Paul asked for this.