### PR TITLE
Fixing storage issues with created svgs

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -138,7 +138,7 @@ VectorShape.prototype.imageURL = function () {
 
     svg.children = [ this.asSVG() ];
 
-    return 'data:image/svg+xml, ' + svg;
+    return 'data:image/svg+xml;base64,' + svg;
 };
 
 VectorShape.prototype.copy = function (newShape) {
@@ -1525,7 +1525,7 @@ VectorPaintEditorMorph.prototype.getSVG = function () {
 
     svg.children = this.shapes.map(function (shape) { return shape.asSVG(); });
 
-    return svg;
+    return window.btoa(svg);
 };
 
 VectorPaintEditorMorph.prototype.getBounds = function (shapeCollection) {
@@ -1573,7 +1573,7 @@ VectorPaintEditorMorph.prototype.ok = function () {
 
     this.paper.updateAutomaticCenter();
 
-    img.src = 'data:image/svg+xml, ' + this.getSVG().toString();
+    img.src = 'data:image/svg+xml;base64,' + this.getSVG().toString();
 
     img.onload = function() {
         myself.callback(


### PR DESCRIPTION
These little changes fix #2125 
- As Jens said, general svgs (also svgs from Snap! library) are (for now) not editable. We can only edit svgs created with Snap! vector editor.
- But now I can export "snap svg costumes" with a right format. So...
  - Exported "snap svgs" can be imported to other projects (and they are still editable).
  - I can open all exported svgs with a desktop vector editor.
  - Svgs edited with a vector editor can be imported into Snap! projects... but now they are "general svgs" (not created by Snap!) and then, they are not editable.

This is all!