### PR TITLE
Fixing cache issues with url block

### DIFF
--- a/threads.js
+++ b/threads.js
@@ -2301,6 +2301,7 @@ Process.prototype.reportURL = function (url) {
         }
         this.httpRequest = new XMLHttpRequest();
         this.httpRequest.open("GET", url, true);
+        this.httpRequest.setRequestHeader('Cache-Control', 'max-age=0');
         this.httpRequest.send(null);
         if (this.context.isCustomCommand) {
             // special case when ignoring the result, e.g. when


### PR DESCRIPTION
Hi,
After some Snap4Arduino issues about URL block (like [this last one](https://github.com/bromagosa/Snap4Arduino/issues/247) I've been studying this.

Some behaviors are not predictable... and sometimes the issue is in the Server side... but I see many times Snap requests have a "Caution: Provisional headers shown" warning... and this is a bad behavior because it was returning cached values without any request to the server.

I see browsers (Firefox and Chrome) has not this issue, and they have a `Cache-Control: max-age=0` header. Then I've tested, and adding this header to our request (into URL block) the issue is gone.

Thanks

Joan