### PR TITLE
Fix #1918 - escape options in block drop downs

### DIFF
--- a/store.js
+++ b/store.js
@@ -2022,9 +2022,10 @@ CustomBlockDefinition.prototype.toXML = function (serializer) {
                             ' readonly="true"' : '',
                     myself.declarations.get(decl)[1],
                     myself.declarations.get(decl)[2] ?
-                            '<options>' + myself.declarations.get(decl)[2] +
-                                '</options>'
-                                : ''
+                            serializer.format(
+                                '<options>@</options>',
+                                myself.declarations.get(decl)[2]
+                            ) : ''
                 );
             }, ''),
         this.body ? serializer.store(this.body.expression) : '',


### PR DESCRIPTION
Adds a missing escape call.